### PR TITLE
PCX-2243: Revert to junit4 for unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ ext {
     lombokVersion = '1.18.20'
 
     gsonVersion = '2.8.8'
-    junitJupiterVersion = '5.8.1'
     androidMaterialVersion = '1.4.0'
     androidxBrowserVersion = '1.3.0'
     androidxSwiperefreshlayoutVersion = '1.1.0'
@@ -57,10 +56,13 @@ ext {
     androidxTestJunitVersion = '1.1.3'
     androidxTestUIAutomatorVersion = '2.2.0'
 
+    junitVersion = '4.13.2'
     rxjavaVersion = '3.1.1'
     rxandroidVersion = '3.0.0'
     mockitoCoreVersion = '2.23.4'
+    robolectricVersion = '4.5.1'
     jsonsnapshotVersion = '1.0.17'
+    tngDataProviderVersion = '2.8'
 }
 
 static def getCurrentBranch() {

--- a/checkout/build.gradle
+++ b/checkout/build.gradle
@@ -56,9 +56,10 @@ dependencies {
 
     compileOnly "org.projectlombok:lombok:${rootProject.lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${rootProject.lombokVersion}"
+    testImplementation "org.robolectric:robolectric:${rootProject.robolectricVersion}"
     testImplementation "androidx.test:core:${rootProject.androidxTestCoreVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.junitJupiterVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:${rootProject.junitJupiterVersion}"
+    testImplementation "junit:junit:${rootProject.junitVersion}"
+    testImplementation "com.tngtech.junit.dataprovider:junit4-dataprovider:${tngDataProviderVersion}"
     testImplementation "io.github.json-snapshot:json-snapshot:${rootProject.jsonsnapshotVersion}"
 }
 

--- a/checkout/src/test/java/com/payoneer/checkout/core/PaymentInputTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/core/PaymentInputTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class PaymentInputTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/core/PaymentNetworkCodesTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/core/PaymentNetworkCodesTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class PaymentNetworkCodesTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/form/BrowserDataBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/form/BrowserDataBuilderTest.java
@@ -8,24 +8,24 @@
 
 package com.payoneer.checkout.form;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.BrowserData;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class BrowserDataBuilderTest {
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void createFromContext_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            BrowserDataBuilder.createFromContext(null);
-        });
+        BrowserDataBuilder.createFromContext(null);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/localization/InteractionMessageTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/InteractionMessageTest.java
@@ -8,26 +8,26 @@
 
 package com.payoneer.checkout.localization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.Interaction;
 import com.payoneer.checkout.model.InteractionCode;
 import com.payoneer.checkout.model.InteractionReason;
 import com.payoneer.checkout.model.NetworkOperationType;
 
+@RunWith(RobolectricTestRunner.class)
 public class InteractionMessageTest {
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void fromInteraction_invalidInteraction_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            InteractionMessage.fromInteraction(null);
-        });
+        InteractionMessage.fromInteraction(null);
     }
 
     @Test
@@ -39,11 +39,9 @@ public class InteractionMessageTest {
         assertNull(message.getFlow());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void fromDeleteFlow_invalidInteraction_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            InteractionMessage.fromDeleteFlow(null);
-        });
+        InteractionMessage.fromDeleteFlow(null);
     }
 
     @Test
@@ -55,20 +53,16 @@ public class InteractionMessageTest {
         assertEquals("DELETE", message.getFlow());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void fromOperationFlow_invalidInteraction_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            String operationType = NetworkOperationType.CHARGE;
-            InteractionMessage.fromOperationFlow(null, operationType);
-        });
+        String operationType = NetworkOperationType.CHARGE;
+        InteractionMessage.fromOperationFlow(null, operationType);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void fromOperationFlow_invalidOperationType_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Interaction interaction = new Interaction(InteractionCode.PROCEED, InteractionReason.OK);
-            InteractionMessage.fromOperationFlow(interaction, "");
-        });
+        Interaction interaction = new Interaction(InteractionCode.PROCEED, InteractionReason.OK);
+        InteractionMessage.fromOperationFlow(interaction, "");
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/localization/LocalLocalizationHolderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/LocalLocalizationHolderTest.java
@@ -8,13 +8,16 @@
 
 package com.payoneer.checkout.localization;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class LocalLocalizationHolderTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/localization/LocalizationCacheTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/LocalizationCacheTest.java
@@ -8,11 +8,11 @@
 
 package com.payoneer.checkout.localization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class LocalizationCacheTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/localization/LocalizationTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/LocalizationTest.java
@@ -10,14 +10,16 @@ package com.payoneer.checkout.localization;
 
 import static com.payoneer.checkout.localization.LocalizationKey.LABEL_TEXT;
 import static com.payoneer.checkout.localization.LocalizationKey.LABEL_TITLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.Interaction;
 import com.payoneer.checkout.model.InteractionCode;
@@ -27,6 +29,7 @@ import com.payoneer.checkout.model.NetworkOperationType;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public final class LocalizationTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/localization/MapLocalizationHolderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/MapLocalizationHolderTest.java
@@ -8,11 +8,14 @@
 
 package com.payoneer.checkout.localization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+@RunWith(RobolectricTestRunner.class)
 public class MapLocalizationHolderTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/localization/MultiLocalizationHolderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/localization/MultiLocalizationHolderTest.java
@@ -8,11 +8,14 @@
 
 package com.payoneer.checkout.localization;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+@RunWith(RobolectricTestRunner.class)
 public class MultiLocalizationHolderTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/markdown/MarkdownSpannableStringBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/markdown/MarkdownSpannableStringBuilderTest.java
@@ -8,12 +8,15 @@
 
 package com.payoneer.checkout.markdown;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import android.text.SpannableStringBuilder;
 
+@RunWith(RobolectricTestRunner.class)
 public class MarkdownSpannableStringBuilderTest {
 
     @Test
@@ -32,7 +35,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParse_whenInputContainsLinks_shouldReturnStringContainingLinkText() {
-        final String input = "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/) and [Privacy Policy](https://www.google.com/).";
+        final String input =
+            "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/) and [Privacy Policy](https://www.google.com/).";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         assertEquals("By clicking the button, you agree to the Terms of Service and Privacy Policy.", result.toString());
     }
@@ -64,7 +68,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParseLinks_whenInputContains2Links_shouldReturnAttributedStringWith2Links() {
-        final String input = "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/) and [Privacy Policy](https://www.google.com/).";
+        final String input =
+            "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/) and [Privacy Policy](https://www.google.com/).";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         MarkdownLinkSpan[] spans = result.getSpans(0, result.length(), MarkdownLinkSpan.class);
         assertEquals(2, spans.length);
@@ -74,7 +79,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParseLinks_whenInputContains2LinksTogether_shouldReturnAttributedStringWith2Links() {
-        final String input = "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/)[Privacy Policy](https://www.google.com/).";
+        final String input =
+            "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/)[Privacy Policy](https://www.google.com/).";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         MarkdownLinkSpan[] spans = result.getSpans(0, result.length(), MarkdownLinkSpan.class);
         assertEquals(2, spans.length);
@@ -84,7 +90,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParseLinks_whenInputContains2LinksWithoutWhitespace_shouldReturnAttributedStringWith2Links() {
-        final String input = "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/)and[Privacy Policy](https://www.google.com/).";
+        final String input =
+            "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/)and[Privacy Policy](https://www.google.com/).";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         MarkdownLinkSpan[] spans = result.getSpans(0, result.length(), MarkdownLinkSpan.class);
         assertEquals(2, spans.length);
@@ -103,7 +110,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParseLinks_whenInputContains2LinksWithOptionalTitle_shouldReturn2Links() {
-        final String input = "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/ \"optional title\") and [Privacy Policy](https://www.google.com/ \"optionaltitle\").";
+        final String input =
+            "By clicking the button, you agree to the [Terms of Service](https://www.apple.com/ \"optional title\") and [Privacy Policy](https://www.google.com/ \"optionaltitle\").";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         MarkdownLinkSpan[] spans = result.getSpans(0, result.length(), MarkdownLinkSpan.class);
         assertEquals(2, spans.length);
@@ -121,7 +129,8 @@ public class MarkdownSpannableStringBuilderTest {
 
     @Test
     public void testParseLinks_whenInputContains2LinksWithNoSpaces_shouldReturn2LinksWithLinkTexts() {
-        final String input = "Byclickingthebutton,youagreetothe[TermsofService](https://www.apple.com/ \"optionaltitle\")and[PrivacyPolicy](https://www.google.com/ \"optionaltitle\").";
+        final String input =
+            "Byclickingthebutton,youagreetothe[TermsofService](https://www.apple.com/ \"optionaltitle\")and[PrivacyPolicy](https://www.google.com/ \"optionaltitle\").";
         SpannableStringBuilder result = MarkdownSpannableStringBuilder.createFromText(input);
         MarkdownLinkSpan[] spans = result.getSpans(0, result.length(), MarkdownLinkSpan.class);
         assertEquals(2, spans.length);

--- a/checkout/src/test/java/com/payoneer/checkout/model/CheckboxModeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/CheckboxModeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class CheckboxModeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/HttpMethodTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/HttpMethodTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class HttpMethodTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/InputElementTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/InputElementTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class InputElementTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/IntegrationTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/IntegrationTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class IntegrationTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/InteractionCodeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/InteractionCodeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class InteractionCodeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/InteractionReasonTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/InteractionReasonTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class InteractionReasonTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/NetworkOperationTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/NetworkOperationTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class NetworkOperationTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/PaymentMethodTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/PaymentMethodTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class PaymentMethodTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/ProductTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/ProductTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class ProductTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/RedirectTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/RedirectTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class RedirectTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/model/RegistrationTypeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/model/RegistrationTypeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.model;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class RegistrationTypeTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/network/ListConnectionTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/network/ListConnectionTest.java
@@ -8,44 +8,63 @@
 
 package com.payoneer.checkout.network;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import com.payoneer.checkout.core.PaymentException;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+/**
+ * The type List connection test.
+ */
+@RunWith(RobolectricTestRunner.class)
 public class ListConnectionTest {
 
-    @Test
-    public void createPaymentSession_invalidBaseUrl_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            ListConnection conn = createListConnection();
-            conn.createPaymentSession(null, "auth123", "{}");
-        });
+    /**
+     * Create payment session invalid baseUrl
+     *
+     * @throws PaymentException the network exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void createPaymentSession_invalidBaseUrl_IllegalArgumentException() throws PaymentException {
+        ListConnection conn = createListConnection();
+        conn.createPaymentSession(null, "auth123", "{}");
     }
 
-    @Test
-    public void createPaymentSession_invalidAuthorization_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            ListConnection conn = createListConnection();
-            conn.createPaymentSession("http://localhost", null, "{}");
-        });
+    /**
+     * Create payment session invalid authorization
+     *
+     * @throws PaymentException the network exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void createPaymentSession_invalidAuthorization_IllegalArgumentException() throws PaymentException {
+        ListConnection conn = createListConnection();
+        conn.createPaymentSession("http://localhost", null, "{}");
     }
 
-    @Test
-    public void createPaymentSession_invalidListData_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            ListConnection conn = createListConnection();
-            conn.createPaymentSession("http://localhost", "auth123", "");
-        });
+    /**
+     * Create payment session invalid list data
+     *
+     * @throws PaymentException the network exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void createPaymentSession_invalidListData_IllegalArgumentException() throws PaymentException {
+        ListConnection conn = createListConnection();
+        conn.createPaymentSession("http://localhost", "auth123", "");
     }
 
-    @Test
-    public void getListResult_invalidURL_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            ListConnection conn = createListConnection();
-            conn.getListResult(null);
-        });
+    /**
+     * Gets list result invalid url
+     *
+     * @throws PaymentException the network exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void getListResult_invalidURL_IllegalArgumentException() throws PaymentException {
+        ListConnection conn = createListConnection();
+        conn.getListResult(null);
     }
 
     private ListConnection createListConnection() {

--- a/checkout/src/test/java/com/payoneer/checkout/network/LocalizationConnectionTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/network/LocalizationConnectionTest.java
@@ -8,20 +8,28 @@
 
 package com.payoneer.checkout.network;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import com.payoneer.checkout.core.PaymentException;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+/**
+ * The type Localization connection test.
+ */
+@RunWith(RobolectricTestRunner.class)
 public class LocalizationConnectionTest {
 
-    @Test
-    public void loadLocalizationHolder_invalidURL_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Context context = ApplicationProvider.getApplicationContext();
-            LocalizationConnection conn = new LocalizationConnection(context);
-            conn.loadLocalization(null);
-        });
+    /**
+     * Gets LocalizationHolder with invalid URL
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void loadLocalizationHolder_invalidURL_IllegalArgumentException() throws PaymentException {
+        Context context = ApplicationProvider.getApplicationContext();
+        LocalizationConnection conn = new LocalizationConnection(context);
+        conn.loadLocalization(null);
     }
 }

--- a/checkout/src/test/java/com/payoneer/checkout/network/PaymentConnectionTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/network/PaymentConnectionTest.java
@@ -8,18 +8,28 @@
 
 package com.payoneer.checkout.network;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import com.payoneer.checkout.core.PaymentException;
 
 import androidx.test.core.app.ApplicationProvider;
 
+/**
+ * The type Operation connection test.
+ */
+@RunWith(RobolectricTestRunner.class)
 public class PaymentConnectionTest {
 
-    @Test
-    public void createOperation_invalidData_exception() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            PaymentConnection conn = new PaymentConnection(ApplicationProvider.getApplicationContext());
-            conn.postOperation(null);
-        });
+    /**
+     * Post operation invalid data invalid value error.
+     *
+     * @throws PaymentException the network exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void createOperation_invalidData_exception() throws PaymentException {
+        PaymentConnection conn = new PaymentConnection(ApplicationProvider.getApplicationContext());
+        conn.postOperation(null);
     }
 }

--- a/checkout/src/test/java/com/payoneer/checkout/network/UserAgentBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/network/UserAgentBuilderTest.java
@@ -8,17 +8,19 @@
 
 package com.payoneer.checkout.network;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import android.content.Context;
 import android.text.TextUtils;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class UserAgentBuilderTest {
 
     private final String SDK_VERSION_NAME = "5.3.0";
@@ -32,11 +34,9 @@ public class UserAgentBuilderTest {
     private final String BUILD_MODEL = "Android SDK built for x86_64";
     private final String BUILD_VERSION_RELEASE = "9";
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void createFromContext_IllegalArgumentException() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            UserAgentBuilder.createFromContext(null);
-        });
+        UserAgentBuilder.createFromContext(null);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectRequestTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectRequestTest.java
@@ -8,41 +8,39 @@
 
 package com.payoneer.checkout.redirect;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.core.PaymentException;
 import com.payoneer.checkout.model.OperationResult;
 import com.payoneer.checkout.model.Redirect;
 import com.payoneer.checkout.test.util.TestUtils;
 
+@RunWith(RobolectricTestRunner.class)
 public class RedirectRequestTest {
 
-    @Test
-    public void fromOperationResult_missingRedirect() {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            int requestCode = 1;
-            OperationResult operationResult = new OperationResult();
-            operationResult.setLinks(createLinks());
-            RedirectRequest.fromOperationResult(requestCode, operationResult);
-        });
+    @Test(expected = PaymentException.class)
+    public void fromOperationResult_missingRedirect() throws PaymentException {
+        int requestCode = 1;
+        OperationResult operationResult = new OperationResult();
+        operationResult.setLinks(createLinks());
+        RedirectRequest.fromOperationResult(requestCode, operationResult);
     }
 
-    @Test
-    public void fromOperationResult_missingLink() {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            int requestCode = 1;
-            OperationResult operationResult = new OperationResult();
-            operationResult.setRedirect(new Redirect());
-            RedirectRequest.fromOperationResult(requestCode, operationResult);
-        });
+    @Test(expected = PaymentException.class)
+    public void fromOperationResult_missingLink() throws PaymentException {
+        int requestCode = 1;
+        OperationResult operationResult = new OperationResult();
+        operationResult.setRedirect(new Redirect());
+        RedirectRequest.fromOperationResult(requestCode, operationResult);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectServiceTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectServiceTest.java
@@ -8,11 +8,13 @@
 
 package com.payoneer.checkout.redirect;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.HttpMethod;
 import com.payoneer.checkout.model.Redirect;
@@ -21,6 +23,7 @@ import com.payoneer.checkout.test.util.TestUtils;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class RedirectServiceTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectUriBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/redirect/RedirectUriBuilderTest.java
@@ -8,13 +8,15 @@
 
 package com.payoneer.checkout.redirect;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.Parameter;
 import com.payoneer.checkout.model.Redirect;
@@ -22,6 +24,7 @@ import com.payoneer.checkout.test.util.TestUtils;
 
 import android.net.Uri;
 
+@RunWith(RobolectricTestRunner.class)
 public class RedirectUriBuilderTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/resource/ResourceLoaderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/resource/ResourceLoaderTest.java
@@ -8,13 +8,14 @@
 
 package com.payoneer.checkout.resource;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.core.PaymentException;
@@ -22,14 +23,13 @@ import com.payoneer.checkout.core.PaymentException;
 import android.content.res.Resources;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class ResourceLoaderTest {
 
-    @Test
-    public void loadPaymentGroups_invalidResourceId() {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            Resources res = ApplicationProvider.getApplicationContext().getResources();
-            ResourceLoader.loadPaymentGroups(res, 0);
-        });
+    @Test(expected = PaymentException.class)
+    public void loadPaymentGroups_invalidResourceId() throws PaymentException {
+        Resources res = ApplicationProvider.getApplicationContext().getResources();
+        ResourceLoader.loadPaymentGroups(res, 0);
     }
 
     @Test
@@ -41,12 +41,10 @@ public class ResourceLoaderTest {
         assertNotNull(groups.get("AMEX"));
     }
 
-    @Test
-    public void loadValidations_invalidResourceId() {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            Resources res = ApplicationProvider.getApplicationContext().getResources();
-            ResourceLoader.loadValidations(res, 0);
-        });
+    @Test(expected = PaymentException.class)
+    public void loadValidations_invalidResourceId() throws PaymentException {
+        Resources res = ApplicationProvider.getApplicationContext().getResources();
+        ResourceLoader.loadValidations(res, 0);
     }
 
     @Test
@@ -67,12 +65,10 @@ public class ResourceLoaderTest {
         validateGroup(validations, "MAESTROUK");
     }
 
-    @Test
-    public void readRawResource_invalidResourceId() {
-        Assertions.assertThrows(IOException.class, () -> {
-            Resources res = ApplicationProvider.getApplicationContext().getResources();
-            ResourceLoader.readRawResource(res, 0);
-        });
+    @Test(expected = IOException.class)
+    public void readRawResource_invalidResourceId() throws IOException {
+        Resources res = ApplicationProvider.getApplicationContext().getResources();
+        ResourceLoader.readRawResource(res, 0);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/PaymentResultTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/PaymentResultTest.java
@@ -8,9 +8,11 @@
 
 package com.payoneer.checkout.ui;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.ErrorInfo;
 import com.payoneer.checkout.model.Interaction;
@@ -20,6 +22,7 @@ import com.payoneer.checkout.model.OperationResult;
 
 import android.os.Parcel;
 
+@RunWith(RobolectricTestRunner.class)
 public class PaymentResultTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionBuilderTest.java
@@ -8,13 +8,12 @@
 
 package com.payoneer.checkout.ui.service;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import com.payoneer.checkout.core.PaymentException;
 import com.payoneer.checkout.model.ListResult;
@@ -23,24 +22,20 @@ import com.payoneer.checkout.ui.model.PaymentSession;
 
 public class PaymentSessionBuilderTest {
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void build_missingListResult() throws PaymentException {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            Map<String, PaymentGroup> paymentGroups = new HashMap<>();
-            new PaymentSessionBuilder()
-                .setPaymentGroups(paymentGroups)
-                .build();
-        });
+        Map<String, PaymentGroup> paymentGroups = new HashMap<>();
+        new PaymentSessionBuilder()
+            .setPaymentGroups(paymentGroups)
+            .build();
     }
 
-    @Test
-    public void build_missingPaymentGroups() {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            ListResult listResult = new ListResult();
-            new PaymentSessionBuilder()
-                .setListResult(listResult)
-                .build();
-        });
+    @Test(expected = IllegalStateException.class)
+    public void build_missingPaymentGroups() throws PaymentException {
+        ListResult listResult = new ListResult();
+        new PaymentSessionBuilder()
+            .setListResult(listResult)
+            .build();
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionServiceTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Payoneer Germany GmbH
+ * Copyright (c) 2020 Payoneer Germany GmbH
  * https://www.payoneer.com
  *
  * This file is open source and available under the MIT license.
@@ -8,16 +8,19 @@
 
 package com.payoneer.checkout.ui.service;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.model.NetworkOperationType;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class PaymentSessionServiceTest {
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionServiceTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/service/PaymentSessionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Payoneer Germany GmbH
+ * Copyright (c) 2021 Payoneer Germany GmbH
  * https://www.payoneer.com
  *
  * This file is open source and available under the MIT license.

--- a/checkout/src/test/java/com/payoneer/checkout/ui/service/RegistrationOptionsBuilderTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/service/RegistrationOptionsBuilderTest.java
@@ -15,12 +15,13 @@ import static com.payoneer.checkout.model.RegistrationType.FORCED_DISPLAYED;
 import static com.payoneer.checkout.model.RegistrationType.NONE;
 import static com.payoneer.checkout.model.RegistrationType.OPTIONAL;
 import static com.payoneer.checkout.model.RegistrationType.OPTIONAL_PRESELECTED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.core.PaymentException;
 import com.payoneer.checkout.localization.LocalizationKey;
@@ -30,6 +31,7 @@ import com.payoneer.checkout.model.RegistrationType;
 import com.payoneer.checkout.ui.model.RegistrationOptions;
 import com.payoneer.checkout.ui.model.RegistrationOptions.RegistrationOption;
 
+@RunWith(RobolectricTestRunner.class)
 public class RegistrationOptionsBuilderTest {
 
     // First value is the autoRegistration type and second value is the allowRecurrence type
@@ -73,32 +75,26 @@ public class RegistrationOptionsBuilderTest {
         { FORCED, FORCED, CheckboxMode.NONE }
     };
 
-    @Test
-    public void buildRegistrationOptions_missingOperationType() {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
-            builder.setRegistrationOptions(RegistrationType.OPTIONAL, RegistrationType.OPTIONAL);
-            builder.buildRegistrationOptions();
-        });
+    @Test(expected = IllegalStateException.class)
+    public void buildRegistrationOptions_missingOperationType() throws PaymentException {
+        RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
+        builder.setRegistrationOptions(RegistrationType.OPTIONAL, RegistrationType.OPTIONAL);
+        builder.buildRegistrationOptions();
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void buildRegistrationOptions_missingRegistrationOptions() throws PaymentException {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
-            builder.setOperationType(NetworkOperationType.UPDATE);
-            builder.buildRegistrationOptions();
-        });
+        RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
+        builder.setOperationType(NetworkOperationType.UPDATE);
+        builder.buildRegistrationOptions();
     }
 
-    @Test
+    @Test(expected = PaymentException.class)
     public void buildRegistrationOptions_invalidRegistrationOptions() throws PaymentException {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
-            builder.setOperationType(NetworkOperationType.UPDATE);
-            builder.setRegistrationOptions(RegistrationType.NONE, RegistrationType.OPTIONAL);
-            builder.buildRegistrationOptions();
-        });
+        RegistrationOptionsBuilder builder = new RegistrationOptionsBuilder();
+        builder.setOperationType(NetworkOperationType.UPDATE);
+        builder.setRegistrationOptions(RegistrationType.NONE, RegistrationType.OPTIONAL);
+        builder.buildRegistrationOptions();
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/theme/PaymentThemeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/theme/PaymentThemeTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.ui.theme;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.ui.PaymentTheme;

--- a/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/EditTextInputModeFactoryTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/EditTextInputModeFactoryTest.java
@@ -8,9 +8,9 @@
 
 package com.payoneer.checkout.ui.widget.input;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import com.payoneer.checkout.core.PaymentInputType;
 import com.payoneer.checkout.model.InputElement;

--- a/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/ExpiryDateTextWatcherTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/ExpiryDateTextWatcherTest.java
@@ -10,8 +10,9 @@ package com.payoneer.checkout.ui.widget.input;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import android.content.Context;
 import android.text.Editable;
@@ -20,13 +21,12 @@ import android.text.TextWatcher;
 import android.widget.EditText;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class ExpiryDateTextWatcherTest {
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void createExpiryDateTextWatcher_invalid_EditText() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            new ExpiryDateTextWatcher(null);
-        });
+        new ExpiryDateTextWatcher(null);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/GroupingTextWatcherTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/widget/input/GroupingTextWatcherTest.java
@@ -10,8 +10,9 @@ package com.payoneer.checkout.ui.widget.input;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import android.content.Context;
 import android.text.Editable;
@@ -20,22 +21,19 @@ import android.text.TextWatcher;
 import android.widget.EditText;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class GroupingTextWatcherTest {
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void createGroupingTextWatcher_invalid_EditText() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            new GroupingTextWatcher(4, null);
-        });
+        new GroupingTextWatcher(4, null);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void createGroupingTextWatcher_invalid_Grouping() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Context context = ApplicationProvider.getApplicationContext();
-            EditText editText = new EditText(context);
-            new GroupingTextWatcher(0, editText);
-        });
+        Context context = ApplicationProvider.getApplicationContext();
+        EditText editText = new EditText(context);
+        new GroupingTextWatcher(0, editText);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/util/GsonHelperTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/util/GsonHelperTest.java
@@ -8,14 +8,16 @@
 
 package com.payoneer.checkout.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.google.gson.reflect.TypeToken;
 import com.payoneer.checkout.core.PaymentInputType;
@@ -25,6 +27,7 @@ import com.payoneer.checkout.model.InputElementType;
 /**
  * Class for testing the GsonHelper methods
  */
+@RunWith(RobolectricTestRunner.class)
 public class GsonHelperTest {
 
     private final static String jsonArray =

--- a/checkout/src/test/java/com/payoneer/checkout/util/PaymentUtilsTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/util/PaymentUtilsTest.java
@@ -11,10 +11,10 @@ package com.payoneer.checkout.util;
 import static com.payoneer.checkout.model.PaymentMethod.CREDIT_CARD;
 import static com.payoneer.checkout.model.PaymentMethod.DEBIT_CARD;
 import static com.payoneer.checkout.model.PaymentMethod.WALLET;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,8 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.core.PaymentInputType;
@@ -36,6 +37,7 @@ import androidx.test.core.app.ApplicationProvider;
 /**
  * Class for testing the PaymentUtils class
  */
+@RunWith(RobolectricTestRunner.class)
 public class PaymentUtilsTest {
 
     @Test
@@ -109,12 +111,10 @@ public class PaymentUtilsTest {
         assertEquals(displayLabel, PaymentUtils.getAccountMaskLabel(accountMask, WALLET));
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void readRawResource_missing_resource() throws IOException {
-        Assertions.assertThrows(IOException.class, () -> {
-            Resources res = ApplicationProvider.getApplicationContext().getResources();
-            PaymentUtils.readRawResource(res, -1);
-        });
+        Resources res = ApplicationProvider.getApplicationContext().getResources();
+        PaymentUtils.readRawResource(res, -1);
     }
 
     @Test

--- a/checkout/src/test/java/com/payoneer/checkout/validation/CardNumberValidatorTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/validation/CardNumberValidatorTest.java
@@ -8,10 +8,10 @@
 
 package com.payoneer.checkout.validation;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class CardNumberValidatorTest {
 

--- a/checkout/src/test/java/com/payoneer/checkout/validation/HolderNameValidatorTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/validation/HolderNameValidatorTest.java
@@ -8,11 +8,16 @@
 
 package com.payoneer.checkout.validation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+@RunWith(DataProviderRunner.class)
 public class HolderNameValidatorTest {
 
     private static final String HOLDER_NAME_DATA_PROVIDER = "holder-name-data-provider";
@@ -26,13 +31,14 @@ public class HolderNameValidatorTest {
     private static final String VERY_LONG_INVALID_HOLDER_NAME_INPUT =
         "Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234 5678 9012 34 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 12345678 Aäsdfölkëdjf 1231234123412342134 Oijajsdf908 Asdf 123456780 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890 Aäsdfölkëdjf 123 Oijajsdf908 Asdf 1234567890";
 
-    @ParameterizedTest
-    @MethodSource("holderNameDataProvider")
+    @Test
+    @UseDataProvider("holderNameDataProvider")
     public void isValidHolderName(final String input, final boolean expectedValid) {
         boolean result = HolderNameValidator.isValidHolderName(input);
         assertEquals(result, expectedValid);
     }
 
+    @DataProvider
     public static Object[][] holderNameDataProvider() {
         return new Object[][] {
             // test input, is the test input valid

--- a/checkout/src/test/java/com/payoneer/checkout/validation/IbanValidatorTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/validation/IbanValidatorTest.java
@@ -8,8 +8,8 @@
 
 package com.payoneer.checkout.validation;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 

--- a/checkout/src/test/java/com/payoneer/checkout/validation/ValidatorTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/validation/ValidatorTest.java
@@ -8,16 +8,17 @@
 
 package com.payoneer.checkout.validation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.core.PaymentException;
@@ -29,20 +30,17 @@ import com.payoneer.checkout.resource.ResourceLoader;
 import android.content.res.Resources;
 import androidx.test.core.app.ApplicationProvider;
 
+@RunWith(RobolectricTestRunner.class)
 public class ValidatorTest {
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void createInstance_invalidContext() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new Validator(null);
-        });
+        new Validator(null);
     }
 
-    @Test
-    public void createInstance_invalidResource() {
-        Assertions.assertThrows(PaymentException.class, () -> {
-            createValidator(0);
-        });
+    @Test(expected = PaymentException.class)
+    public void createInstance_invalidResource() throws PaymentException {
+        createValidator(0);
     }
 
     @Test
@@ -75,20 +73,17 @@ public class ValidatorTest {
         assertFalse(validator.isHidden(PaymentNetworkCodes.VISA, PaymentInputType.HOLDER_NAME));
     }
 
-    @Test
-    public void validate_invalidMethod() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final Validator validator = createValidator(R.raw.validations);
-            validator.validate(null, PaymentNetworkCodes.VISA, PaymentInputType.ACCOUNT_NUMBER, "4111111111111111", null);
-        });
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validate_invalidMethod() throws PaymentException {
+        final Validator validator = createValidator(R.raw.validations);
+        validator.validate(null, PaymentNetworkCodes.VISA, PaymentInputType.ACCOUNT_NUMBER, "4111111111111111", null);
     }
 
-    @Test
-    public void validate_invalidType() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final Validator validator = createValidator(R.raw.validations);
-            validator.validate(PaymentMethod.CREDIT_CARD, PaymentNetworkCodes.VISA, null, "4111111111111111", null);
-        });
+    @Test(expected = IllegalArgumentException.class)
+    public void validate_invalidType() throws PaymentException {
+        final Validator validator = createValidator(R.raw.validations);
+        validator.validate(PaymentMethod.CREDIT_CARD, PaymentNetworkCodes.VISA, null, "4111111111111111", null);
     }
 
     @Test

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -8,24 +8,13 @@
 
 package com.payoneer.checkout.examplecheckout;
 
-import static androidx.test.espresso.intent.Intents.intended;
-import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
-import static com.payoneer.checkout.sharedtest.checkout.MagicNumbers.CHARGE_PROCEED_OK;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.payoneer.checkout.model.InteractionCode;
-import com.payoneer.checkout.model.InteractionReason;
-import com.payoneer.checkout.sharedtest.checkout.ChargePaymentHelper;
-import com.payoneer.checkout.sharedtest.checkout.PaymentDialogHelper;
 import com.payoneer.checkout.sharedtest.checkout.PaymentListHelper;
 import com.payoneer.checkout.sharedtest.service.ListSettings;
-import com.payoneer.checkout.sharedtest.view.UiDeviceHelper;
-import com.payoneer.checkout.ui.page.PaymentListActivity;
 
-import androidx.test.espresso.IdlingResource;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
@@ -38,7 +27,7 @@ public final class ExtraElementTests extends AbstractTest {
     private final static String EXTRAELEMENTS_BOTTOM_CONFIG = "UITests-ExtraElements-Bottom";
     private final static String EXTRAELEMENTS_TOP_CONFIG = "UITests-ExtraElements-Top";
     private final static String EXTRAELEMENTS_TOPBOTTOM_CONFIG = "UITests-ExtraElements-TopBottom";
-    
+
     @Rule
     public ActivityTestRule<ExampleCheckoutActivity> rule = new ActivityTestRule<>(ExampleCheckoutActivity.class);
 


### PR DESCRIPTION
Junit5 using Jupiter does not work yet correctly with Android Studio and Github Actions.
Reverting back to Junit4 to correctly run tests through CI.