### PR TITLE
PCX-2259: Test commit on develop

### DIFF
--- a/.github/workflows/testcommit.yml
+++ b/.github/workflows/testcommit.yml
@@ -1,0 +1,30 @@
+# Workflow for releasing the Android Checkout SDK
+
+name: Test
+on:
+  push:
+    branches:
+      - "develop"
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    name: "Version"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
+      - name: Remove Snapshot from version
+        run: |
+          ./gradlew createTestList
+          git add './shared-test/lists/test.json'
+          git commit --message "Test commit from pull request"
+          git push


### PR DESCRIPTION
This is a test to verify permissions to commit in a Github Actions through a build account compared to a normal developer account.