### PR TITLE
PCX-2275: Fix reference to browserstack example file

### DIFF
--- a/example-checkout/browserstack.gradle
+++ b/example-checkout/browserstack.gradle
@@ -26,5 +26,5 @@ task runFunctionalTest {
 browserStackConfig {
     username = rootProject.browserStackUser
     accessKey = rootProject.browserStackKey
-    configFilePath = 'example-shop/browserstack.json'
+    configFilePath = 'example-checkout/browserstack.json'
 }


### PR DESCRIPTION
**bug description**
ExampleCheckout app is using the ExampleShop browserstack profile