### PR TITLE
PCX-2289: Scroll and open the correct selected payment card

### DIFF
--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/HeaderItem.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/HeaderItem.java
@@ -29,4 +29,14 @@ final class HeaderItem extends ListItem {
     public String getMessage() {
         return message;
     }
+
+    /**
+     * Check if the provided ListItem is a HeaderItem
+     *
+     * @param listItem the list item to be checked
+     * @return true when a HeaderItem, false otherwise
+     */
+    public final static boolean isHeaderItem(ListItem listItem) {
+        return (listItem != null) && (listItem instanceof HeaderItem);
+    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
@@ -34,7 +34,7 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public @NonNull
     ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         ListItem item = itemList.getItemWithViewType(viewType);
-        if (item instanceof HeaderItem) {
+        if (ListItem.isHeaderItem(item)) {
             return HeaderViewHolder.createInstance(parent);
         }
         PaymentCard card = ((PaymentCardItem)item).getPaymentCard();
@@ -51,12 +51,12 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         ListItem item = itemList.getItem(position);
 
-        if (item instanceof PaymentCardItem) {
+        if (ListItem.isHeaderItem(item)) {
+            ((HeaderViewHolder) holder).onBind((HeaderItem) item);
+        } else {
             PaymentCardViewHolder ph = (PaymentCardViewHolder) holder;
             ph.onBind();
             ph.expand(itemList.getSelectedIndex() == position);
-        } else {
-            ((HeaderViewHolder) holder).onBind((HeaderItem) item);
         }
     }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
@@ -34,16 +34,16 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public @NonNull
     ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         ListItem item = itemList.getItemWithViewType(viewType);
-        PaymentCard card = item != null ? item.getPaymentCard() : null;
-
+        if (item instanceof HeaderItem) {
+            return HeaderViewHolder.createInstance(parent);
+        }
+        PaymentCard card = ((PaymentCardItem)item).getPaymentCard();
         if (card instanceof NetworkCard) {
             return NetworkCardViewHolder.createInstance(this, (NetworkCard) card, parent);
         } else if (card instanceof AccountCard) {
             return AccountCardViewHolder.createInstance(this, (AccountCard) card, parent);
-        } else if (card instanceof PresetCard) {
-            return PresetCardViewHolder.createInstance(this, (PresetCard) card, parent);
         } else {
-            return HeaderViewHolder.createInstance(parent);
+            return PresetCardViewHolder.createInstance(this, (PresetCard) card, parent);
         }
     }
 
@@ -51,7 +51,7 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         ListItem item = itemList.getItem(position);
 
-        if (item.hasPaymentCard()) {
+        if (item instanceof PaymentCardItem) {
             PaymentCardViewHolder ph = (PaymentCardViewHolder) holder;
             ph.onBind();
             ph.expand(itemList.getSelectedIndex() == position);

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListAdapter.java
@@ -34,7 +34,7 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public @NonNull
     ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         ListItem item = itemList.getItemWithViewType(viewType);
-        if (ListItem.isHeaderItem(item)) {
+        if (HeaderItem.isHeaderItem(item)) {
             return HeaderViewHolder.createInstance(parent);
         }
         PaymentCard card = ((PaymentCardItem)item).getPaymentCard();
@@ -51,7 +51,7 @@ final class ListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         ListItem item = itemList.getItem(position);
 
-        if (ListItem.isHeaderItem(item)) {
+        if (HeaderItem.isHeaderItem(item)) {
             ((HeaderViewHolder) holder).onBind((HeaderItem) item);
         } else {
             PaymentCardViewHolder ph = (PaymentCardViewHolder) holder;

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
@@ -20,12 +20,4 @@ abstract class ListItem {
     ListItem(int viewType) {
         this.viewType = viewType;
     }
-
-    boolean hasPaymentCard() {
-        return false;
-    }
-
-    PaymentCard getPaymentCard() {
-        return null;
-    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
@@ -20,14 +20,4 @@ abstract class ListItem {
     ListItem(int viewType) {
         this.viewType = viewType;
     }
-
-    /**
-     * Check if this ListItem is a HeaderItem
-     *
-     * @param listItem the item to be checked
-     * @return true when a HeaderItem, false otherwise
-     */
-    public final static boolean isHeaderItem(ListItem listItem) {
-        return (listItem != null) && (listItem instanceof HeaderItem);
-    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/ListItem.java
@@ -20,4 +20,14 @@ abstract class ListItem {
     ListItem(int viewType) {
         this.viewType = viewType;
     }
+
+    /**
+     * Check if this ListItem is a HeaderItem
+     *
+     * @param listItem the item to be checked
+     * @return true when a HeaderItem, false otherwise
+     */
+    public final static boolean isHeaderItem(ListItem listItem) {
+        return (listItem != null) && (listItem instanceof HeaderItem);
+    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentCardItem.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentCardItem.java
@@ -25,8 +25,4 @@ final class PaymentCardItem extends ListItem {
     PaymentCard getPaymentCard() {
         return paymentCard;
     }
-
-    boolean hasPaymentCard() {
-        return true;
-    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentCardViewHolder.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentCardViewHolder.java
@@ -364,8 +364,4 @@ public abstract class PaymentCardViewHolder extends RecyclerView.ViewHolder {
             }
         }
     }
-
-    String createWidgetKey(String inputCategory, String inputName) {
-        return inputCategory + "." + inputName;
-    }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentItemList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentItemList.java
@@ -57,13 +57,6 @@ final class PaymentItemList {
         return items.size();
     }
 
-    boolean isHeaderItem(int index) {
-        if ((index < 0) || (index >= items.size())) {
-            return false;
-        }
-        return (items.get(index) instanceof HeaderItem);
-    }
-
     int getItemViewType(int index) {
         return items.get(index).viewType;
     }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentItemList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentItemList.java
@@ -57,6 +57,13 @@ final class PaymentItemList {
         return items.size();
     }
 
+    boolean isHeaderItem(int index) {
+        if ((index < 0) || (index >= items.size())) {
+            return false;
+        }
+        return (items.get(index) instanceof HeaderItem);
+    }
+
     int getItemViewType(int index) {
         return items.get(index).viewType;
     }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
@@ -90,12 +90,18 @@ public final class PaymentList {
 
         setVisible(true);
         adapter.notifyDataSetChanged();
-
-        recyclerView.scrollToPosition(itemList.getSelectedIndex());
+        scrollToSelectedCard();
     }
 
     public void setVisible(boolean visible) {
         recyclerView.setVisibility(visible ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    private void scrollToSelectedCard() {
+        int selectedIndex = itemList.getSelectedIndex();
+        if (selectedIndex > 1) {
+            recyclerView.scrollToPosition(selectedIndex);
+        }
     }
 
     private PaymentCardListener createCardListener() {

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
@@ -98,10 +98,13 @@ public final class PaymentList {
     }
 
     private void scrollToSelectedCard() {
-        int selectedIndex = itemList.getSelectedIndex();
-        if (selectedIndex > 1) {
-            recyclerView.scrollToPosition(selectedIndex);
-        }
+        int scrollPosition = calculateScrollPosition(itemList.getSelectedIndex());
+        recyclerView.scrollToPosition(scrollPosition);
+    }
+
+    private int calculateScrollPosition(int index) {
+        int headerIndex = (index - 1);
+        return (itemList.isHeaderItem(headerIndex)) ? headerIndex : index;
     }
 
     private PaymentCardListener createCardListener() {
@@ -178,7 +181,8 @@ public final class PaymentList {
             itemList.setSelectedIndex(position);
             adapter.notifyItemChanged(curIndex);
             adapter.notifyItemChanged(position);
-            scrollAndCloseKeyboard(position);
+            int scrollPosition = calculateScrollPosition(position);
+            scrollAndCloseKeyboard(scrollPosition);
         }
     }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
@@ -100,8 +100,9 @@ public final class PaymentList {
     }
 
     private int calculateScrollPosition(int index) {
-        int headerIndex = (index - 1);
-        return (itemList.isHeaderItem(headerIndex)) ? headerIndex : index;
+        int headerIndex = index - 1;
+        ListItem item = itemList.getItem(headerIndex);
+        return (ListItem.isHeaderItem(item)) ? headerIndex : index;
     }
 
     private PaymentCardListener createCardListener() {

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
@@ -90,16 +90,13 @@ public final class PaymentList {
 
         setVisible(true);
         adapter.notifyDataSetChanged();
-        scrollToSelectedCard();
+
+        int scrollPosition = calculateScrollPosition(itemList.getSelectedIndex());
+        recyclerView.scrollToPosition(scrollPosition);
     }
 
     public void setVisible(boolean visible) {
         recyclerView.setVisibility(visible ? View.VISIBLE : View.INVISIBLE);
-    }
-
-    private void scrollToSelectedCard() {
-        int scrollPosition = calculateScrollPosition(itemList.getSelectedIndex());
-        recyclerView.scrollToPosition(scrollPosition);
     }
 
     private int calculateScrollPosition(int index) {
@@ -181,8 +178,7 @@ public final class PaymentList {
             itemList.setSelectedIndex(position);
             adapter.notifyItemChanged(curIndex);
             adapter.notifyItemChanged(position);
-            int scrollPosition = calculateScrollPosition(position);
-            scrollAndCloseKeyboard(scrollPosition);
+            scrollAndCloseKeyboard(calculateScrollPosition(position));
         }
     }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/list/PaymentList.java
@@ -102,7 +102,7 @@ public final class PaymentList {
     private int calculateScrollPosition(int index) {
         int headerIndex = index - 1;
         ListItem item = itemList.getItem(headerIndex);
-        return (ListItem.isHeaderItem(item)) ? headerIndex : index;
+        return (HeaderItem.isHeaderItem(item)) ? headerIndex : index;
     }
 
     private PaymentCardListener createCardListener() {

--- a/checkout/src/main/java/com/payoneer/checkout/ui/model/AccountCard.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/model/AccountCard.java
@@ -90,7 +90,7 @@ public final class AccountCard extends PaymentCard {
     }
 
     @Override
-    public boolean isPreselected() {
+    public boolean hasSelectedNetwork() {
         return PaymentUtils.isTrue(account.getSelected());
     }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/model/NetworkCard.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/model/NetworkCard.java
@@ -35,6 +35,16 @@ public final class NetworkCard extends PaymentCard {
     }
 
     @Override
+    public boolean hasSelectedNetwork() {
+        for (PaymentNetwork network : networks) {
+            if (network.hasSelectedNetwork()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void putLanguageLinks(Map<String, URL> links) {
         for (PaymentNetwork network : networks) {
             network.putLanguageLink(links);
@@ -82,16 +92,6 @@ public final class NetworkCard extends PaymentCard {
     @Override
     public List<InputElement> getInputElements() {
         return getVisibleNetwork().getInputElements();
-    }
-
-    @Override
-    public boolean isPreselected() {
-        for (PaymentNetwork network : networks) {
-            if (network.isPreselected()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override

--- a/checkout/src/main/java/com/payoneer/checkout/ui/model/PaymentCard.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/model/PaymentCard.java
@@ -33,6 +33,7 @@ public abstract class PaymentCard {
     private boolean checkable;
     private boolean hideInputForm;
     private boolean disabled;
+    private boolean preselected;
     final List<String> userInputTypes;
 
     /**
@@ -171,6 +172,25 @@ public abstract class PaymentCard {
     }
 
     /**
+     * Set the PaymentCard to being preselected, this means that the card will be expanded
+     * when the list is shown for the first time.
+     *
+     * @param preselected expand the card when true, false show a collapsed card
+     */
+    public void setPreselected(final boolean preselected) {
+        this.preselected = preselected;
+    }
+
+    /**
+     * Is this card preselected
+     *
+     * @return true when preselected, false otherwise
+     */
+    public boolean isPreselected() {
+        return preselected;
+    }
+
+    /**
      * Does this PaymentCard has any form elements
      *
      * @return true when the form has elements, false otherwise
@@ -239,6 +259,13 @@ public abstract class PaymentCard {
     }
 
     /**
+     * Does this PaymentCard has a network that is selected by the Payment API
+     *
+     * @return true when selected, false otherwise
+     */
+    public abstract boolean hasSelectedNetwork();
+
+    /**
      * Check if this card contains a link with the provided name. If the card contains multiple networks then
      * all networks must be checked if at least one of them contains the link.
      *
@@ -283,13 +310,6 @@ public abstract class PaymentCard {
      * @return network code of this PaymentCard
      */
     public abstract String getNetworkCode();
-
-    /**
-     * Is this card preselected
-     *
-     * @return true when preselected, false otherwise
-     */
-    public abstract boolean isPreselected();
 
     /**
      * Get the title of this PaymentCard

--- a/checkout/src/main/java/com/payoneer/checkout/ui/model/PaymentNetwork.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/model/PaymentNetwork.java
@@ -73,7 +73,7 @@ public final class PaymentNetwork {
         return registrationOptions;
     }
 
-    public boolean isPreselected() {
+    public boolean hasSelectedNetwork() {
         return PaymentUtils.isTrue(network.getSelected());
     }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/model/PresetCard.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/model/PresetCard.java
@@ -54,6 +54,11 @@ public final class PresetCard extends PaymentCard {
     }
 
     @Override
+    public boolean hasSelectedNetwork() {
+        return false;
+    }
+
+    @Override
     public String getPaymentMethod() {
         return account.getMethod();
     }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/service/PaymentSessionBuilder.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/service/PaymentSessionBuilder.java
@@ -103,6 +103,7 @@ public final class PaymentSessionBuilder {
         if (section != null) {
             sections.add(section);
         }
+        setPreselectedCard(sections);
         boolean refreshable = UPDATE.equals(operationType);
         return new PaymentSession(listResult, sections, refreshable);
     }
@@ -291,5 +292,35 @@ public final class PaymentSessionBuilder {
             return;
         }
         card.getSmartSwitch().addSelectionRegex(code, regex);
+    }
+
+    /**
+     * Set the card that should be expanded when the list is shown for the first time.
+     * A card is marked as preselected in the following order:
+     *
+     * 1. The card has a network that is marked selected by the Payment API
+     * 2. The card is presenting a PresetAccount
+     * 3. It is the only card in the entire list
+     *
+     * @param paymentSections containing the sections of PaymentCards
+     */
+    private void setPreselectedCard(List<PaymentSection> paymentSections) {
+        List<PaymentCard> cards = new ArrayList<>();
+        for (PaymentSection section : paymentSections) {
+            cards.addAll(section.getPaymentCards());
+        }
+        if (cards.size() == 0) {
+            return;
+        }
+        for (PaymentCard card : cards) {
+            if (card.hasSelectedNetwork()) {
+                card.setPreselected(true);
+                return;
+            }
+        }
+        PaymentCard card = cards.get(0);
+        if ((card instanceof PresetCard) || cards.size() == 1) {
+            card.setPreselected(true);
+        }
     }
 }


### PR DESCRIPTION
When loading a LIST object with a PRESET account, the first thing viewable in the viewport is the UI card for the PRESET account, while the section title (“Previously selected”) and (potential) warning text are not visible.