### PR TITLE
PCX-2331: fix Browserstack workflows

### DIFF
--- a/.github/workflows/app_automate_test_examplecheckout.yml
+++ b/.github/workflows/app_automate_test_examplecheckout.yml
@@ -28,4 +28,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew :example-checkout:executeTestsOnAppAutomate
+        run: ./gradlew testExampleCheckoutOnAppAutomate

--- a/.github/workflows/app_automate_test_exampleshop.yml
+++ b/.github/workflows/app_automate_test_exampleshop.yml
@@ -28,4 +28,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew :example-shop:executeTestsOnAppAutomate
+        run: ./gradlew testExampleShopOnAppAutomate

--- a/.github/workflows/app_live_upload_examplecheckout.yml
+++ b/.github/workflows/app_live_upload_examplecheckout.yml
@@ -28,4 +28,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew :example-checkout:uploadToAppLive
+        run: ./gradlew uploadExampleCheckout

--- a/.github/workflows/app_live_upload_examplecheckout.yml
+++ b/.github/workflows/app_live_upload_examplecheckout.yml
@@ -27,5 +27,6 @@ jobs:
           MOBILE_MERCHANT_PAYMENT_TOKEN: ${{ secrets.MOBILE_MERCHANT_PAYMENT_TOKEN }}
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+          BROWSERSTACK_TEST: ${{ secrets.BROWSERSTACK_TEST }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
         run: ./gradlew uploadExampleCheckout

--- a/.github/workflows/app_live_upload_examplecheckout.yml
+++ b/.github/workflows/app_live_upload_examplecheckout.yml
@@ -27,6 +27,5 @@ jobs:
           MOBILE_MERCHANT_PAYMENT_TOKEN: ${{ secrets.MOBILE_MERCHANT_PAYMENT_TOKEN }}
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-          BROWSERSTACK_TEST: ${{ secrets.BROWSERSTACK_TEST }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
         run: ./gradlew uploadExampleCheckout

--- a/.github/workflows/app_live_upload_examplecheckout.yml
+++ b/.github/workflows/app_live_upload_examplecheckout.yml
@@ -28,4 +28,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew uploadExampleCheckout
+        run: ./gradlew uploadExampleCheckoutToAppLive

--- a/.github/workflows/app_live_upload_exampleshop.yml
+++ b/.github/workflows/app_live_upload_exampleshop.yml
@@ -28,4 +28,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew :example-shop:uploadToAppLive
+        run: ./gradlew uploadExampleShopToAppLive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
           PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-        run: ./gradlew testExampleApps
+        run: ./gradlew testExampleAppsOnAppAutomate
 
   publish:
     needs: test-examples
@@ -69,4 +69,4 @@ jobs:
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        run: ./gradlew publishSnapshot
+        run: ./gradlew publishCheckoutSnapshotVersion

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
   test-examples:
     name: Test example apps
     needs: test-checkout
-    environment: Browserstack
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
         PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
-      run: ./gradlew testExampleApps
+      run: ./gradlew testExampleAppsOnAppAutomate
 
   release:
     needs: test-examples
@@ -99,4 +99,4 @@ jobs:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-        run: ./gradlew publishRelease
+        run: ./gradlew publishCheckoutReleaseVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
   test-examples:
     name: Test example apps
     needs: test-checkout
-    environment: Browserstack
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/checkout/publish.gradle
+++ b/checkout/publish.gradle
@@ -1,4 +1,4 @@
-task publishSnapshot {
+task publishSnapshotVersion {
     if (rootProject.nexusUser == null || rootProject.nexusPassword == null) {
         logger.lifecycle('[PUBLISH-SNAPSHOT] Missing nexusUser and/or nexusPassword environment variables')
         return
@@ -10,7 +10,7 @@ task publishSnapshot {
     dependsOn 'publish'
 }
 
-task publishRelease {
+task publishReleaseVersion {
     if (rootProject.nexusUser == null || rootProject.nexusPassword == null) {
         logger.lifecycle('[PUBLISH-RELEASE] Missing nexusUser and/or nexusPassword environment variables')
         return

--- a/ci.gradle
+++ b/ci.gradle
@@ -11,23 +11,34 @@ task testCheckout() {
     dependsOn ':checkout:test'
 }
 
-task publishShapshot() {
-    dependsOn ':checkout:publishSnapshot'
+task publishCheckoutShapshotVersion() {
+    dependsOn ':checkout:publishSnapshotVersion'
 }
 
-task publishRelease() {
-    dependsOn ':checkout:publishRelease'
+task publishCheckoutReleaseVersion() {
+    dependsOn ':checkout:publishReleaseVersion'
 }
 
-task testExampleApps() {
-    def testExampleCheckout = tasks.findByPath(':example-checkout:executeTestsOnAppAutomate')
-    def testExampleShop = tasks.findByPath(':example-shop:executeTestsOnAppAutomate')
+task uploadExampleCheckoutToAppLive() {
+    dependsOn ':example-checkout:uploadToAppLive'
+}
+
+task uploadExampleShopToAppLive() {
+    dependsOn ':example-shop:uploadToAppLive'
+}
+
+task testExampleCheckoutOnAppAutomate() {
+    dependsOn ':example-checkout:testOnAppAutomate'
+}
+
+task testExampleShopOnAppAutomate() {
+    dependsOn ':example-shop:testOnAppAutomate'
+}
+
+task testExampleAppsOnAppAutomate() {
+    def testExampleCheckout = tasks.findByPath(':example-checkout:testOnAppAutomate')
+    def testExampleShop = tasks.findByPath(':example-shop:testOnAppAutomate')
     dependsOn testExampleCheckout
     dependsOn testExampleShop
     testExampleShop.mustRunAfter(testExampleCheckout)
-}
-
-task uploadExampleCheckout() {
-    print "TEST: " + System.getenv('BROWSERSTACK_TEST')
-    dependsOn ':example-checkout:uploadToAppLive'
 }

--- a/ci.gradle
+++ b/ci.gradle
@@ -26,3 +26,7 @@ task testExampleApps() {
     dependsOn testExampleShop
     testExampleShop.mustRunAfter(testExampleCheckout)
 }
+
+task uploadExampleCheckout() {
+    dependsOn ':example-checkout:uploadToAppLive'
+}

--- a/ci.gradle
+++ b/ci.gradle
@@ -28,5 +28,6 @@ task testExampleApps() {
 }
 
 task uploadExampleCheckout() {
+    print "TEST: " + System.getenv('BROWSERSTACK_TEST')
     dependsOn ':example-checkout:uploadToAppLive'
 }

--- a/example-checkout/browserstack.gradle
+++ b/example-checkout/browserstack.gradle
@@ -10,7 +10,7 @@ task uploadToAppLive {
     dependsOn('uploadExampleCheckoutDebugToBrowserstackAppLive')
 }
 
-task executeTestsOnAppAutomate {
+task testOnAppAutomate {
     if ((rootProject.merchantCode == null) || (rootProject.merchantPaymentToken == null) ||
             (rootProject.paymentApiListUrl == null)) {
         logger.lifecycle('[BROWSERSTACK] Missing functional test settings')

--- a/example-shop/browserstack.gradle
+++ b/example-shop/browserstack.gradle
@@ -10,7 +10,7 @@ task uploadToAppLive {
     dependsOn('uploadExampleShopDebugToBrowserstackAppLive')
 }
 
-task executeTestsOnAppAutomate {
+task testOnAppAutomate {
     if ((rootProject.merchantCode == null) || (rootProject.merchantPaymentToken == null) ||
             (rootProject.paymentApiListUrl == null)) {
         logger.lifecycle('[BROWSERSTACK] Missing functional test settings')


### PR DESCRIPTION
**AS** A developer
**I LIKE** to upload and test the Checkout SDK example apps from Github
**SO THAT** anybody can easily test and use the Android Checkout Examples

**Acceptance Criteria**
Create 4 manual Github Workflow actions

- Upload example-checkout app to Browserstack App live
- Upload example-shop app to Browserstack App live
- Run example-checkout UITests on Browserstack
- Run example-shop UITests on Browserstack

Both uploading and testing should be done on the active branch