### PR TITLE
PCX-2567: Fix back navigation crash

### DIFF
--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseTest.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseTest.java
@@ -14,6 +14,7 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -23,9 +24,11 @@ import org.junit.Before;
 import com.payoneer.checkout.sharedtest.service.ListService;
 import com.payoneer.checkout.sharedtest.service.ListSettings;
 import com.payoneer.checkout.sharedtest.view.UiDeviceHelper;
+import com.payoneer.checkout.ui.PaymentActivityResult;
 import com.payoneer.checkout.ui.page.ChargePaymentActivity;
 import com.payoneer.checkout.ui.page.PaymentListActivity;
 
+import android.app.Activity;
 import android.content.Context;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
@@ -55,6 +58,15 @@ public abstract class BaseTest {
     protected void matchResultInteraction(String interactionCode, String interactionReason) {
         onView(withId(R.id.text_interactioncode)).check(matches(withText(interactionCode)));
         onView(withId(R.id.text_interactionreason)).check(matches(withText(interactionReason)));
+    }
+
+    protected void matchResultCodeCanceled() {
+        String resultCode = PaymentActivityResult.resultCodeToString(Activity.RESULT_CANCELED);
+        this.matchResultCode(resultCode);
+    }
+
+    protected void matchResultCode(String resultCode) {
+        onView(withId(R.id.text_resultcode)).check(matches(withText(resultCode)));
     }
 
     protected ListSettings createDefaultListSettings() {
@@ -107,5 +119,9 @@ public abstract class BaseTest {
 
     protected void waitForAppRelaunch() {
         UiDeviceHelper.waitUiObjectHasPackage("com.payoneer.checkout.examplecheckout");
+    }
+
+    protected void pressActionBarUp() {
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click());
     }
 }

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/CancelPaymentTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/CancelPaymentTests.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright (c) 2021 Payoneer Germany GmbH
+ * https://www.payoneer.com
+ *
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more information.
+ *
+ */
+
+package com.payoneer.checkout.examplecheckout;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.payoneer.checkout.sharedtest.checkout.PaymentListHelper;
+
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class CancelPaymentTests extends BaseJavaTest {
+
+    @Test
+    public void testCancelPaymentClickActionBarUp() {
+        IdlingResource resultIdlingResource = getResultIdlingResource();
+        enterListUrl(createListUrl());
+        clickShowPaymentListButton();
+
+        PaymentListHelper.waitForPaymentListLoaded(1);
+        pressActionBarUp();
+
+        register(resultIdlingResource);
+        matchResultCodeCanceled();
+        unregister(resultIdlingResource);
+    }
+
+    @Test
+    public void testCancelPaymentPressBack() {
+        IdlingResource resultIdlingResource = getResultIdlingResource();
+        enterListUrl(createListUrl());
+        clickShowPaymentListButton();
+
+        PaymentListHelper.waitForPaymentListLoaded(1);
+        Espresso.pressBack();
+
+        register(resultIdlingResource);
+        matchResultCodeCanceled();
+        unregister(resultIdlingResource);
+    }
+}
+

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/CheckoutJavaTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/CheckoutJavaTests.java
@@ -30,6 +30,20 @@ import androidx.test.filters.LargeTest;
 public class CheckoutJavaTests extends BaseJavaTest {
 
     @Test
+    public void testCancelPaymentClickActionBarUp() {
+        IdlingResource resultIdlingResource = getResultIdlingResource();
+        enterListUrl(createListUrl());
+        clickShowPaymentListButton();
+
+        PaymentListHelper.waitForPaymentListLoaded(1);
+        pressActionBarUp();
+
+        register(resultIdlingResource);
+        matchResultCodeCanceled();
+        unregister(resultIdlingResource);
+    }
+
+    @Test
     public void testPayPalRedirect_directCharge_customerAccept() {
         IdlingResource resultIdlingResource = getResultIdlingResource();
         enterListUrl(createListUrl());

--- a/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutKotlinActivity.kt
+++ b/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutKotlinActivity.kt
@@ -12,6 +12,7 @@ package com.payoneer.checkout.examplecheckout
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Patterns
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
@@ -54,7 +55,7 @@ class ExampleCheckoutKotlinActivity : AppCompatActivity() {
         super.onResume()
         resultHandled = false
         if (activityResult != null) {
-            showPaymentActivityResult(activityResult)
+            showPaymentActivityResult(activityResult!!)
             setResultHandledIdleState(true)
         }
     }
@@ -136,32 +137,30 @@ class ExampleCheckoutKotlinActivity : AppCompatActivity() {
         PaymentTheme.createDefault()
     }
 
-    private fun showPaymentActivityResult(sdkResult: PaymentActivityResult?) {
-        if (sdkResult != null) {
-            val resultCode = sdkResult.resultCode
-            val paymentResult = sdkResult.paymentResult
+    private fun showPaymentActivityResult(sdkResult: PaymentActivityResult) {
+        val resultCode = sdkResult.resultCode
+        val paymentResult = sdkResult.paymentResult
 
-            val info = paymentResult.resultInfo
-            val interaction = paymentResult.interaction
-            val code = interaction.code
-            val reason = interaction.reason
-            val cause = paymentResult.cause
-            val error = cause?.message
+        val info = paymentResult?.resultInfo
+        val interaction = paymentResult?.interaction
+        val code = interaction?.code
+        val reason = interaction?.reason
+        val cause = paymentResult?.cause
+        val error = cause?.message
 
-            binding.apply {
-                labelResultheader.isVisible = true
-                layoutResult.isVisible = true
-                textResultinfo.setLabel(info)
-                textInteractioncode.setLabel(code)
-                textInteractionreason.setLabel(reason)
-                textPaymenterror.setLabel(error ?: "")
-                textResultcode.setLabel(PaymentActivityResult.resultCodeToString(resultCode))
-            }
+        binding.apply {
+            labelResultheader.isVisible = true
+            layoutResult.isVisible = true
+            textResultinfo.setLabel(info)
+            textInteractioncode.setLabel(code)
+            textInteractionreason.setLabel(reason)
+            textPaymenterror.setLabel(error)
+            textResultcode.setLabel(PaymentActivityResult.resultCodeToString(resultCode))
         }
     }
 
-    private fun TextView.setLabel(message: String) {
-        val label = if (message.isEmpty()) this.context.getString(R.string.empty_label) else message
+    private fun TextView.setLabel(message: String?) {
+        val label = if (TextUtils.isEmpty(message)) this.context.getString(R.string.empty_label) else message
         this.text = label
     }
 


### PR DESCRIPTION
Clicking the back button causes the app to crash in the Kotlin Example app.

**Acceptance Criteria**

Back button should be clickable

Automated UI tests should be written to test the back button in both the Example Checkout (Kotlin, Java) and Example Shop app.

**Details**

1. Platform/System/environment
Android Checkout SDK

2. Steps to reproduce
Open Checkout Example app and click the top/left back button

3. Current behaviour
NullPointerException is thrown

4. Expected behaviour
App should show that the user canceled the payment page

5. Test parameters how to reproduce
ANDROID_TESTING merchant on main integration