### PR TITLE
PCX-2895: Update workflow files for testing example apps for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,12 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@v2
         with:
-          submodules: recursive
+          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
       - name: Clean checkout project
         run: ./gradlew clean
       - name: Test examples on Browserstack

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -26,6 +26,31 @@ jobs:
       - name: Run checkout unit-tests
         run: ./gradlew testCheckout
 
+  test-examples:
+    name: Test example apps
+    needs: test-checkout
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Test examples on Browserstack
+        env:
+          MOBILE_MERCHANT_CODE: ${{ secrets.MOBILE_MERCHANT_CODE }}
+          MOBILE_MERCHANT_PAYMENT_TOKEN: ${{ secrets.MOBILE_MERCHANT_PAYMENT_TOKEN }}
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+          PAYMENTAPI_LISTURL: ${{ secrets.PAYMENTAPI_LISTURL }}
+        run: ./gradlew testExampleAppsOnAppAutomate
+
   test-riskproviders:
     name: Test risk providers
     needs: test-checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
       - name: Clean checkout project
         run: ./gradlew clean
       - name: Test examples on Browserstack


### PR DESCRIPTION
## WHAT

All automated UI tests currently in the Android Checkout SDK should be run on Browserstack for all pull requests into develop branch. (Excluding draft PRs). Currently, only unit tests are run and this should be extended with automated UI tests.

See https://optile.atlassian.net/browse/PCX-2895