### PR TITLE
PCX-2555: Change theme parameters in CheckoutTheme

### DIFF
--- a/checkout/src/main/java/com/payoneer/checkout/Checkout.java
+++ b/checkout/src/main/java/com/payoneer/checkout/Checkout.java
@@ -35,7 +35,7 @@ public final class Checkout {
      * @param checkoutConfiguration contains the listUrl and theming
      * @return newly created Checkout Object
      */
-    public static Checkout from(final CheckoutConfiguration checkoutConfiguration) {
+    public static Checkout of(final CheckoutConfiguration checkoutConfiguration) {
         if (checkoutConfiguration == null) {
             throw new IllegalArgumentException("checkoutConfiguration cannot be null");
         }

--- a/checkout/src/main/java/com/payoneer/checkout/CheckoutTheme.java
+++ b/checkout/src/main/java/com/payoneer/checkout/CheckoutTheme.java
@@ -16,23 +16,23 @@ import androidx.annotation.StyleRes;
  * Class to hold the theme settings of the screens in the Android SDK
  */
 public final class CheckoutTheme implements Parcelable {
-    private final int paymentListTheme;
-    private final int chargePaymentTheme;
+    private final int toolbarTheme;
+    private final int noToolbarTheme;
 
     private CheckoutTheme(final Builder builder) {
-        this.paymentListTheme = builder.paymentListTheme;
-        this.chargePaymentTheme = builder.chargePaymentTheme;
+        this.toolbarTheme = builder.toolbarTheme;
+        this.noToolbarTheme = builder.noToolbarTheme;
     }
 
     protected CheckoutTheme(final Parcel in) {
-        paymentListTheme = in.readInt();
-        chargePaymentTheme = in.readInt();
+        toolbarTheme = in.readInt();
+        noToolbarTheme = in.readInt();
     }
 
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
-        dest.writeInt(paymentListTheme);
-        dest.writeInt(chargePaymentTheme);
+        dest.writeInt(toolbarTheme);
+        dest.writeInt(noToolbarTheme);
     }
 
     @Override
@@ -58,43 +58,43 @@ public final class CheckoutTheme implements Parcelable {
 
     public static CheckoutTheme createDefault() {
         return createBuilder().
-            setPaymentListTheme(R.style.CheckoutTheme_Toolbar).
-            setChargePaymentTheme(R.style.CheckoutTheme_NoToolbar).
+            setToolbarTheme(R.style.CheckoutTheme_Toolbar).
+            setNoToolbarTheme(R.style.CheckoutTheme_NoToolbar).
             build();
     }
 
-    public int getPaymentListTheme() {
-        return paymentListTheme;
+    public int getToolbarTheme() {
+        return toolbarTheme;
     }
 
-    public int getChargePaymentTheme() {
-        return chargePaymentTheme;
+    public int getNoToolbarTheme() {
+        return noToolbarTheme;
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append("CheckoutTheme [");
-        builder.append("paymentListTheme=").append(paymentListTheme).append(", ");
-        builder.append("chargePaymentTheme=").append(chargePaymentTheme);
+        builder.append("toolbarTheme=").append(toolbarTheme).append(", ");
+        builder.append("noToolbarTheme=").append(noToolbarTheme);
         builder.append("]");
         return builder.toString();
     }
 
     public static final class Builder {
-        int paymentListTheme;
-        int chargePaymentTheme;
+        int toolbarTheme;
+        int noToolbarTheme;
 
         Builder() {
         }
 
-        public Builder setPaymentListTheme(@StyleRes final int paymentListTheme) {
-            this.paymentListTheme = paymentListTheme;
+        public Builder setToolbarTheme(@StyleRes final int toolbarTheme) {
+            this.toolbarTheme = toolbarTheme;
             return this;
         }
 
-        public Builder setChargePaymentTheme(@StyleRes final int chargePaymentTheme) {
-            this.chargePaymentTheme = chargePaymentTheme;
+        public Builder setNoToolbarTheme(@StyleRes final int noToolbarTheme) {
+            this.noToolbarTheme = noToolbarTheme;
             return this;
         }
 

--- a/checkout/src/main/java/com/payoneer/checkout/ui/page/ChargePaymentActivity.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/page/ChargePaymentActivity.java
@@ -92,7 +92,7 @@ public final class ChargePaymentActivity extends BasePaymentActivity implements 
             this.configuration = bundle.getParcelable(EXTRA_CHECKOUT_CONFIGURATION);
         }
         setRequestedOrientation(configuration.getOrientation());
-        int theme = configuration.getCheckoutTheme().getChargePaymentTheme();
+        int theme = configuration.getCheckoutTheme().getNoToolbarTheme();
         if (theme != 0) {
             setTheme(theme);
         }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/page/PaymentListActivity.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/page/PaymentListActivity.java
@@ -68,7 +68,7 @@ public final class PaymentListActivity extends BasePaymentActivity implements Pa
             this.configuration = bundle.getParcelable(EXTRA_CHECKOUT_CONFIGURATION);
         }
         setRequestedOrientation(configuration.getOrientation());
-        int theme = configuration.getCheckoutTheme().getPaymentListTheme();
+        int theme = configuration.getCheckoutTheme().getToolbarTheme();
         if (theme != 0) {
             setTheme(theme);
         }

--- a/checkout/src/test/java/com/payoneer/checkout/ui/theme/CheckoutThemeTest.java
+++ b/checkout/src/test/java/com/payoneer/checkout/ui/theme/CheckoutThemeTest.java
@@ -29,23 +29,23 @@ public class CheckoutThemeTest {
         CheckoutTheme theme = CheckoutTheme.createDefault();
         assertNotNull(theme);
 
-        assertEquals(theme.getPaymentListTheme(), R.style.CheckoutTheme_Toolbar);
-        assertEquals(theme.getChargePaymentTheme(), R.style.CheckoutTheme_NoToolbar);
+        assertEquals(theme.getToolbarTheme(), R.style.CheckoutTheme_Toolbar);
+        assertEquals(theme.getNoToolbarTheme(), R.style.CheckoutTheme_NoToolbar);
     }
 
     @Test
     public void getPaymentListTheme() {
         int value = R.style.CheckoutTheme;
         CheckoutTheme theme = CheckoutTheme.createBuilder().
-            setPaymentListTheme(value).build();
-        assertEquals(theme.getPaymentListTheme(), value);
+            setToolbarTheme(value).build();
+        assertEquals(theme.getToolbarTheme(), value);
     }
 
     @Test
     public void getChargePaymentTheme() {
         int value = R.style.CheckoutTheme;
         CheckoutTheme theme = CheckoutTheme.createBuilder().
-            setChargePaymentTheme(value).build();
-        assertEquals(theme.getChargePaymentTheme(), value);
+            setNoToolbarTheme(value).build();
+        assertEquals(theme.getNoToolbarTheme(), value);
     }
 }

--- a/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutJavaActivity.java
+++ b/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutJavaActivity.java
@@ -126,7 +126,7 @@ public final class ExampleCheckoutJavaActivity extends AppCompatActivity {
         closeKeyboard();
         clearCheckoutResult();
 
-        Checkout checkout = Checkout.from(configuration);
+        Checkout checkout = Checkout.of(configuration);
         checkout.showPaymentList(this, PAYMENT_REQUEST_CODE);
     }
 
@@ -138,7 +138,7 @@ public final class ExampleCheckoutJavaActivity extends AppCompatActivity {
         closeKeyboard();
         clearCheckoutResult();
 
-        Checkout checkout = Checkout.from(configuration);
+        Checkout checkout = Checkout.of(configuration);
         checkout.chargePresetAccount(this, CHARGE_PRESET_ACCOUNT_REQUEST_CODE);
     }
 
@@ -158,8 +158,8 @@ public final class ExampleCheckoutJavaActivity extends AppCompatActivity {
     private CheckoutTheme createCheckoutTheme() {
         if (binding.switchTheme.isChecked()) {
             return CheckoutTheme.createBuilder().
-                setPaymentListTheme(R.style.CustomTheme_Toolbar).
-                setChargePaymentTheme(R.style.CustomTheme_NoToolbar).
+                setToolbarTheme(R.style.CustomTheme_Toolbar).
+                setNoToolbarTheme(R.style.CustomTheme_NoToolbar).
                 build();
         } else {
             return CheckoutTheme.createDefault();

--- a/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutKotlinActivity.kt
+++ b/example-checkout/src/main/java/com/payoneer/checkout/examplecheckout/ExampleCheckoutKotlinActivity.kt
@@ -73,7 +73,7 @@ class ExampleCheckoutKotlinActivity : AppCompatActivity() {
         closeKeyboard()
         clearCheckoutResult()
 
-        val checkout = Checkout.from(checkoutConfiguration)
+        val checkout = Checkout.of(checkoutConfiguration)
         checkout.showPaymentList(this, CHARGE_PRESET_ACCOUNT_REQUEST_CODE)
     }
 
@@ -82,7 +82,7 @@ class ExampleCheckoutKotlinActivity : AppCompatActivity() {
         closeKeyboard()
         clearCheckoutResult()
 
-        val checkout = Checkout.from(checkoutConfiguration)
+        val checkout = Checkout.of(checkoutConfiguration)
         checkout.chargePresetAccount(this, CHARGE_PRESET_ACCOUNT_REQUEST_CODE)
     }
 
@@ -130,8 +130,8 @@ class ExampleCheckoutKotlinActivity : AppCompatActivity() {
     }
 
     private fun createCheckoutTheme(): CheckoutTheme? = if (binding.switchTheme.isChecked) {
-        CheckoutTheme.createBuilder().setPaymentListTheme(R.style.CustomTheme_Toolbar)
-            .setChargePaymentTheme(R.style.CustomTheme_NoToolbar).build()
+        CheckoutTheme.createBuilder().setToolbarTheme(R.style.CustomTheme_Toolbar)
+            .setNoToolbarTheme(R.style.CustomTheme_NoToolbar).build()
     } else {
         CheckoutTheme.createDefault()
     }

--- a/example-shop/src/main/java/com/payoneer/checkout/exampleshop/checkout/CheckoutActivity.kt
+++ b/example-shop/src/main/java/com/payoneer/checkout/exampleshop/checkout/CheckoutActivity.kt
@@ -74,7 +74,7 @@ class CheckoutActivity : BaseActivity() {
     }
 
     private fun onButtonClicked() {
-        val checkout = Checkout.from(checkoutConfiguration)
+        val checkout = Checkout.of(checkoutConfiguration)
         checkout.showPaymentList(this, PAYMENT_REQUEST_CODE)
     }
 

--- a/example-shop/src/main/java/com/payoneer/checkout/exampleshop/summary/SummaryActivity.kt
+++ b/example-shop/src/main/java/com/payoneer/checkout/exampleshop/summary/SummaryActivity.kt
@@ -55,7 +55,7 @@ class SummaryActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySummaryBinding.inflate(layoutInflater)
         layoutSummarydetailsBinding = LayoutSummarydetailsBinding.bind(binding.root)
-        checkout = Checkout.from(checkoutConfiguration)
+        checkout = Checkout.of(checkoutConfiguration)
         setContentView(binding.root)
         initToolbar()
         initListenersAndViews()


### PR DESCRIPTION
## WHAT
Remove dependency to internal naming of screens when setting theming parameters.

## WHY
This allows changing naming of internal screens without having outdated naming for theming.