### PR TITLE
PCX-2974: Remove recurrence and use mastercard

### DIFF
--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseTest.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseTest.java
@@ -94,7 +94,7 @@ public abstract class BaseTest {
         ListService service = createListService();
         String networkCode = PaymentNetworkCodes.VISA;
         AccountInputData inputData = TestDataProvider.expiredAccountInputData();
-        return service.registerAccount(settings, networkCode, inputData, true, true);
+        return service.registerAccount(settings, networkCode, inputData, true, false);
     }
 
     protected void clickShowPaymentListButton() {

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/RegistrationTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/RegistrationTests.java
@@ -80,7 +80,7 @@ public final class RegistrationTests extends BaseKotlinTest {
         // First register an ApplicableNetwork
         PaymentListHelper.waitForPaymentListLoaded(1);
         PaymentListHelper.openPaymentListCard(cardIndex, "card.group");
-        PaymentListHelper.fillPaymentListCard(cardIndex, TestDataProvider.visaCardTestData());
+        PaymentListHelper.fillPaymentListCard(cardIndex, TestDataProvider.masterCardTestData());
         PaymentListHelper.clickPaymentListCardButton(cardIndex);
 
         // Open the newly registered account and click the delete button

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/TestDataProvider.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/TestDataProvider.java
@@ -27,6 +27,15 @@ public final class TestDataProvider {
         return values;
     }
 
+    public static Map<String, String> masterCardTestData() {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("inputelement.number", "5555555555554444");
+        values.put("inputelement.expiryDate", "1245");
+        values.put("inputelement.verificationCode", "123");
+        values.put("inputelement.holderName", "Thomas Smith");
+        return values;
+    }
+
     public static Map<String, String> updateCardData() {
         Map<String, String> values = new LinkedHashMap<>();
         values.put("inputelement.expiryDate", "1245");
@@ -63,7 +72,7 @@ public final class TestDataProvider {
         AccountInputData inputData = new AccountInputData();
         inputData.setExpiryMonth("12");
         inputData.setExpiryYear("2019");
-        inputData.setNumber("4111111111111111");
+        inputData.setNumber("5555555555554444");
         inputData.setVerificationCode("123");
         inputData.setHolderName("Expired User");
         return inputData;


### PR DESCRIPTION
## WHY

Setting the recurrence flag to true will not allow deletion of accounts. The merchant MOBILE_TESTING on  pi-nightly has changed the settings for VISA, whereby the recurrence flag should now be “false”.

See https://optile.atlassian.net/browse/PCX-2974