### PR TITLE
PCX-3279: Fix buildscripts for GooglePay Braintree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         classpath 'gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:3.0.3'
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
         // NOTE: Do not place your application dependencies here; they belong
@@ -67,11 +67,11 @@ ext {
     compileSdkVersion = 31
     targetSdkVersion = 31
 
-    activityVersion = "1.4.0"
-    lifecycleVersion = "2.4.1"
-    hiltVersion = '2.38.1'
-    coreKtxVersion = "1.7.0"
-    gsonVersion = '2.8.9'
+    activityVersion = '1.4.0'
+    lifecycleVersion = '2.4.1'
+    hiltVersion = '2.41'
+    coreKtxVersion = '1.7.0'
+    gsonVersion = '2.9.0'
 
     // Java language implementation
     androidMaterialVersion = '1.5.0'
@@ -86,12 +86,12 @@ ext {
     androidxTestUIAutomatorVersion = '2.2.0'
 
     junitVersion = '4.13.2'
-    rxjavaVersion = '3.1.3'
+    rxjavaVersion = '3.1.4'
     rxandroidVersion = '3.0.0'
     mockitoCoreVersion = '2.23.4'
-    robolectricVersion = '4.7.3'
+    robolectricVersion = '4.8.1'
     jsonsnapshotVersion = '1.0.17'
-    tngDataProviderVersion = '2.8'
+    tngDataProviderVersion = '2.9'
 }
 
 static def getBranchName() {

--- a/checkout/build.gradle
+++ b/checkout/build.gradle
@@ -32,7 +32,7 @@ android {
         }
         libraryVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "PayoneerCheckout_${variant.name}_${versionName}.aar"
+                outputFileName = "PayoneerCheckout-${variant.name}-${versionName}.aar"
             }
         }
         applicationVariants {

--- a/example-checkout/build.gradle
+++ b/example-checkout/build.gradle
@@ -48,7 +48,7 @@ android {
 
             testVariants.all { testVariant ->
                 testVariant.outputs.all { output ->
-                    outputFileName = "ExampleCheckout-${testVariant.buildType.name}_${getBranchLabel()}-androidTest.apk"
+                    outputFileName = "ExampleCheckout-${testVariant.buildType.name}-${getBranchLabel()}-androidTest.apk"
                 }
             }
         }
@@ -61,7 +61,7 @@ android {
         }
         applicationVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "ExampleCheckout-${variant.buildType.name}_${getBranchLabel()}.apk"
+                outputFileName = "ExampleCheckout-${variant.buildType.name}-${getBranchLabel()}.apk"
             }
         }
     }

--- a/example-shop/build.gradle
+++ b/example-shop/build.gradle
@@ -51,7 +51,7 @@ android {
 
             testVariants.all { testVariant ->
                 testVariant.outputs.all { output ->
-                    outputFileName = "ExampleShop-${testVariant.buildType.name}_${getBranchLabel()}-androidTest.apk"
+                    outputFileName = "ExampleShop-${testVariant.buildType.name}-${getBranchLabel()}-androidTest.apk"
                 }
             }
         }
@@ -64,7 +64,7 @@ android {
         }
         applicationVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "ExampleShop-${variant.buildType.name}_${getBranchLabel()}.apk"
+                outputFileName = "ExampleShop-${variant.buildType.name}-${getBranchLabel()}.apk"
             }
         }
     }

--- a/paymentservice/googlepay-braintree/build.gradle
+++ b/paymentservice/googlepay-braintree/build.gradle
@@ -1,28 +1,12 @@
-plugins {
-    id 'com.android.library'
-}
+apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
 
-    defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion rootProject.targetSdkVersion
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+    testOptions {
+        unitTests {
+            includeAndroidResources true
         }
-    }
-
-    lintOptions {
-        abortOnError true
-        checkDependencies true
-        ignoreWarnings true
     }
 
     compileOptions {
@@ -30,24 +14,36 @@ android {
         targetCompatibility rootProject.javaCompatVersion
     }
 
-    testOptions {
-        unitTests {
-            includeAndroidResources true
-        }
+    compileSdkVersion rootProject.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    sourceSets {
-        main {
-            res {
-                srcDirs 'src/main/res'
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+        libraryVariants.all { variant ->
+            variant.outputs.all {
+                outputFileName = "PaymentService-GooglePayBraintree-${variant.name}-${versionName}.aar"
             }
         }
+        applicationVariants {
+        }
+    }
+    lint {
+        abortOnError true
+        checkDependencies true
+        ignoreWarnings true
     }
 }
 
 dependencies {
     compileOnly project(":checkout")
-    implementation "com.google.android.gms:play-services-wallet:16.0.1"
-    implementation "com.braintreepayments.api:google-pay:4.+"
+    implementation "com.braintreepayments.api:google-pay:4.10.1"
     implementation "com.google.android.material:material:${rootProject.androidMaterialVersion}"
 
     testImplementation project(":checkout")
@@ -55,3 +51,6 @@ dependencies {
     testImplementation "androidx.test:core:${rootProject.androidxTestCoreVersion}"
     testImplementation "junit:junit:${rootProject.junitVersion}"
 }
+
+// import the script for publishing release builds to Nexus and Packagecloud
+apply from: 'publish.gradle'

--- a/riskprovider/iovation/build.gradle
+++ b/riskprovider/iovation/build.gradle
@@ -28,7 +28,7 @@ android {
         }
         libraryVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "RiskProvider_Iovation_${variant.name}_${versionName}.aar"
+                outputFileName = "RiskProvider-Iovation-${variant.name}-${versionName}.aar"
             }
         }
         applicationVariants {


### PR DESCRIPTION
## WHAT 

Fix build scripts for GooglePay Braintree.

## WHY

These build scripts upload the Googlepay Braintree module to Nexus and Packagecloud.
Without this update, GooglPay Braintree will not be published to Nexus and Packagecloud.