### PR TITLE
PCX-3317: Disable reload when payment list is resumed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,13 +95,13 @@ ext {
 }
 
 static def getBranchName() {
-    def gitRefName = System.getenv('GITHUB_REF_NAME')
-    if (gitRefName != null) {
-        return gitRefName
-    }
     def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
     if (gitHeadRef != null) {
-        return gitHeadRef
+        return "HR" + gitHeadRef
+    }
+    def gitRefName = System.getenv('GITHUB_REF_NAME')
+    if (gitRefName != null) {
+        return "RN" + gitRefName
     }
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,14 @@ ext {
 }
 
 static def getBranchName() {
+    def gitRefName = System.getenv('GITHUB_REF_NAME')
+    if (gitRefName != null) {
+        return gitRefName
+    }
+    def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
+    if (gitHeadRef != null) {
+        return gitHeadRef
+    }
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()
     proc.in.eachLine { line -> branch = line }

--- a/build.gradle
+++ b/build.gradle
@@ -97,11 +97,11 @@ ext {
 static def getBranchName() {
     def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
     if (gitHeadRef != null) {
-        return "HR" + gitHeadRef
+        return gitHeadRef
     }
     def gitRefName = System.getenv('GITHUB_REF_NAME')
     if (gitRefName != null) {
-        return "RN" + gitRefName
+        return gitRefName
     }
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()

--- a/build.gradle
+++ b/build.gradle
@@ -95,14 +95,6 @@ ext {
 }
 
 static def getBranchName() {
-    def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
-    if (gitHeadRef != null) {
-        return gitHeadRef
-    }
-    def gitRefName = System.getenv('GITHUB_REF_NAME')
-    if (gitRefName != null) {
-        return gitRefName
-    }
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()
     proc.in.eachLine { line -> branch = line }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/screen/list/PaymentListViewModel.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/screen/list/PaymentListViewModel.java
@@ -141,9 +141,14 @@ final class PaymentListViewModel extends AppContextViewModel {
     }
 
     void onPaymentListResume() {
-        if (!serviceInteractor.onResume()) {
-            loadPaymentSession();
+        if (serviceInteractor.onResume()) {
+            return;
         }
+        if (paymentSession != null) {
+            setShowPaymentSession(Resource.SUCCESS, paymentSession);
+            return;
+        }
+        loadPaymentSession();
     }
 
     void onPaymentListPause() {

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExpiredCardTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExpiredCardTests.java
@@ -8,20 +8,15 @@
 
 package com.payoneer.checkout.examplecheckout;
 
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.isViewInPaymentCard;
+import static com.payoneer.checkout.sharedtest.checkout.PaymentListHelper.checkHasVisibleExpiredIcon;
+import static com.payoneer.checkout.sharedtest.checkout.PaymentListHelper.matchesPaymentCardSubtitle;
 
-import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.payoneer.checkout.sharedtest.checkout.PaymentListHelper;
 import com.payoneer.checkout.sharedtest.service.ListSettings;
 
-import android.view.View;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
@@ -42,9 +37,8 @@ public final class ExpiredCardTests extends BaseKotlinTest {
         PaymentListHelper.waitForPaymentListLoaded(1);
         PaymentListHelper.openPaymentListCard(accountCardIndex, "card.account");
 
-        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
-        onView(list).check(matches(isViewInPaymentCard(accountCardIndex, withText("12 / 19"), R.id.text_subtitle)));
-        onView(list).check(matches(isViewInPaymentCard(accountCardIndex, withId(R.id.image_expired_icon), R.id.image_expired_icon)));
+        matchesPaymentCardSubtitle(accountCardIndex, "12 / 19");
+        checkHasVisibleExpiredIcon(accountCardIndex);
     }
 }
 

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -29,6 +29,25 @@ public final class ExtraElementTests extends BaseKotlinTest {
     private final static String EXTRAELEMENTS_TOPBOTTOM_CONFIG = "UITests-ExtraElements-TopBottom";
 
     @Test
+    public void testPaymentList_notReloaded() {
+        ListSettings settings = createDefaultListSettings();
+        settings.setDivision(DIVISION);
+        settings.setCheckoutConfigurationName(EXTRAELEMENTS_BOTTOM_CONFIG);
+        enterListUrl(createListUrl(settings));
+        clickShowPaymentListButton();
+
+        int networkCardIndex = 2;
+        PaymentListHelper.waitForPaymentListLoaded(1);
+        PaymentListHelper.openPaymentListCard(networkCardIndex, "card.network");
+
+        PaymentListHelper.clickExtraElementLinkWithText(networkCardIndex, "extraelement.bottomelement2", "Number 2");
+        clickBrowserPageButton("two", CHROME_CLOSE_BUTTON);
+
+        waitForAppRelaunch();
+        PaymentListHelper.checkIsPaymentCardExpanded(networkCardIndex);
+    }
+
+    @Test
     public void testGroupedNetworks_topElement_clickLink() {
         ListSettings settings = createDefaultListSettings();
         settings.setDivision(DIVISION);

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
@@ -109,9 +109,28 @@ public final class PaymentListHelper {
         onView(withId(R.id.recyclerview_paymentlist)).perform(actionOnViewInPaymentCard(cardIndex, click(), R.id.viewswitcher_icon));
     }
 
+    public static void checkHasVisibleExpiredIcon(final int cardIndex) {
+        intended(hasComponent(PaymentListActivity.class.getName()));
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(matches(isViewInPaymentCard(cardIndex, isDisplayed(), R.id.image_expired_icon)));
+    }
+
+    public static void checkIsPaymentCardExpanded(final int cardIndex) {
+        intended(hasComponent(PaymentListActivity.class.getName()));
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(matches(isViewInPaymentCard(cardIndex, isDisplayed(), R.id.layout_form)));
+    }
+
     public static void matchesPaymentCardTitle(int cardIndex, String title) {
+        intended(hasComponent(PaymentListActivity.class.getName()));
         Matcher<View> list = withId(R.id.recyclerview_paymentlist);
         onView(list).check(matches(isViewInPaymentCard(cardIndex, withText(title), R.id.text_title)));
+    }
+
+    public static void matchesPaymentCardSubtitle(final int cardIndex, final String subtitle) {
+        intended(hasComponent(PaymentListActivity.class.getName()));
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(matches(isViewInPaymentCard(cardIndex, withText(subtitle), R.id.text_subtitle)));
     }
 
     public static void matchesPaymentDialogTitle(String title) {

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/UiDeviceHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/UiDeviceHelper.java
@@ -10,6 +10,8 @@ package com.payoneer.checkout.sharedtest.view;
 
 import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.By;
@@ -27,6 +29,7 @@ public final class UiDeviceHelper {
     public static void checkUiObjectContainsText(String text) {
         UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         UiObject2 uiObject = uiDevice.wait(Until.findObject(By.text(text)), TIMEOUT);
+        assertThat(uiObject, is(notNullValue()));
         assertThat(uiObject.getText(), containsString(text));
     }
 
@@ -34,6 +37,7 @@ public final class UiDeviceHelper {
         UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
 
         UiObject2 uiObject = uiDevice.wait(Until.findObject(By.res(resourceName)), TIMEOUT);
+        assertThat(uiObject, is(notNullValue()));
         uiObject.wait(Until.enabled(true), TIMEOUT);
         uiObject.click();
     }


### PR DESCRIPTION
## Jira ticket
[PCX-3317](https://optile.atlassian.net/browse/PCX-3317)

## Overview/What
When clicking an ExtraElement link which opens the custom chrome tab. After closing the custom tab, the app is reopened but the list is reloaded.

## Cause/Why
The Mobile SDK does not check if there is a previously loaded payment session. It always loads a new one when the PaymentList Screen is resumed.

## Solution
Show the already loaded payment session, if previously loaded.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Test cases

## Tests
- Automated test has been added to validate that the correct payment card is opened when returning from the Chrome Custom tab.