### PR TITLE
PCX-3340: Upload PR Example Checkout app to AppLive

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -56,21 +56,21 @@ jobs:
     needs: test-checkout
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Build payment services
-      run: ./gradlew buildPaymentServices
-    - name: Run payment service unit-tests
-      run: ./gradlew testPaymentServices
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Build payment services
+        run: ./gradlew buildPaymentServices
+      - name: Run payment service unit-tests
+        run: ./gradlew testPaymentServices
 
   test-riskproviders:
     name: Test risk providers
@@ -92,3 +92,25 @@ jobs:
         run: ./gradlew buildRiskProviders
       - name: Run risk provider unit-tests
         run: ./gradlew testRiskProviders
+
+  upload-examples:
+    needs: [ test-examples, test-paymentservices, test-riskproviders ]
+    name: Upload examples to Browserstack AppLive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Upload examples to Browserstack AppLive
+        env:
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: ./gradlew uploadExampleCheckoutToAppLive

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -92,9 +92,9 @@ jobs:
       - name: Run risk provider unit-tests
         run: ./gradlew testRiskProviders
 
-  upload-examples:
+  upload-examplecheckout:
     needs: [ test-examples, test-paymentservices, test-riskproviders ]
-    name: Upload examples to Browserstack AppLive
+    name: Upload ExampleCheckout to Browserstack AppLive
     runs-on: ubuntu-latest
     steps:
       - name: Checkout with submodules
@@ -108,7 +108,7 @@ jobs:
           distribution: 'adopt'
       - name: Clean checkout project
         run: ./gradlew clean
-      - name: Upload examples to Browserstack AppLive
+      - name: Upload ExampleCheckout to Browserstack AppLive
         env:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -113,4 +113,3 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
         run: ./gradlew uploadExampleCheckoutToAppLive
-        

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -9,7 +9,6 @@ jobs:
   test-checkout:
     name: Test checkout module
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -114,3 +113,4 @@ jobs:
           BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
           BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
         run: ./gradlew uploadExampleCheckoutToAppLive
+        

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,14 @@ ext {
 }
 
 static def getBranchName() {
+    def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
+    if (gitHeadRef != null) {
+        return gitHeadRef
+    }
+    def gitRefName = System.getenv('GITHUB_REF_NAME')
+    if (gitRefName != null) {
+        return gitRefName
+    }
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()
     proc.in.eachLine { line -> branch = line }

--- a/example-checkout/browserstack.gradle
+++ b/example-checkout/browserstack.gradle
@@ -10,7 +10,7 @@ task deleteFromAppLive {
         return
     }
     doLast {
-        rootProject.deleteAppLiveWithCustomId("Android-ExampleCheckout-${getBranchName()}")
+        rootProject.deleteAppLiveWithCustomId("Android-ExampleCheckout-${getBranchLabel()}")
     }
 }
 
@@ -38,6 +38,6 @@ task testOnAppAutomate {
 browserStackConfig {
     username = rootProject.browserStackUser
     accessKey = rootProject.browserStackKey
-    customId = "Android-ExampleCheckout-${getBranchName()}"
+    customId = "Android-ExampleCheckout-${getBranchLabel()}"
     configFilePath = 'example-checkout/browserstack.json'
 }

--- a/example-checkout/build.gradle
+++ b/example-checkout/build.gradle
@@ -48,7 +48,7 @@ android {
 
             testVariants.all { testVariant ->
                 testVariant.outputs.all { output ->
-                    outputFileName = "${testVariant.productFlavors[0].name}-${testVariant.buildType.name}_${getBranchLabel()}-androidTest.apk"
+                    outputFileName = "ExampleCheckout-${testVariant.buildType.name}-${getBranchLabel()}-androidTest.apk"
                 }
             }
         }
@@ -61,7 +61,7 @@ android {
         }
         applicationVariants.all { variant ->
             variant.outputs.all {
-                outputFileName = "${variant.productFlavors[0].name}-${variant.buildType.name}_${getBranchLabel()}.apk"
+                outputFileName = "ExampleCheckout-${variant.buildType.name}-${getBranchLabel()}.apk"
             }
         }
     }

--- a/example-shop/browserstack.gradle
+++ b/example-shop/browserstack.gradle
@@ -8,7 +8,7 @@ task deleteFromAppLive {
         return
     }
     doLast {
-        rootProject.deleteAppLiveWithCustomId("Android-ExampleShop-${getBranchName()}")
+        rootProject.deleteAppLiveWithCustomId("Android-ExampleShop-${getBranchLabel()}")
     }
 }
 
@@ -36,6 +36,6 @@ task testOnAppAutomate {
 browserStackConfig {
     username = rootProject.browserStackUser
     accessKey = rootProject.browserStackKey
-    customId = "Android-ExampleShop-${getBranchName()}"
+    customId = "Android-ExampleShop-${getBranchLabel()}"
     configFilePath = 'example-shop/browserstack.json'
 }

--- a/example-shop/build.gradle
+++ b/example-shop/build.gradle
@@ -10,7 +10,6 @@ assemble.dependsOn('lint')
 
 android {
 
-
     compileOptions {
         sourceCompatibility rootProject.javaCompatVersion
         targetCompatibility rootProject.javaCompatVersion


### PR DESCRIPTION
## Jira ticket
[PCX-3340](https://optile.atlassian.net/browse/PCX-3340)

## Overview/What
Upload the Example Checkout app for feature branches to BrowserStack AppLive.

## Cause/Why
As an integration engineer / PO / Support person
I want to be able to access the latest version of our Android SDK Example Checkout app
so that I can compare feature branches to latest and/or present a stable SDK internally or externally

## Solution
For each PR update into develop branch, the Example Checkout app are uploaded to AppLive.

## Type of change
- New feature (non-breaking change which adds functionality)
