### PR TITLE
PCX-2893: Upload example checkout app for develop branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,21 +56,21 @@ jobs:
     needs: test-checkout
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Build payment services
-      run: ./gradlew buildPaymentServices
-    - name: Run payment service unit-tests
-      run: ./gradlew testPaymentServices
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Build payment services
+        run: ./gradlew buildPaymentServices
+      - name: Run payment service unit-tests
+        run: ./gradlew testPaymentServices
 
   test-riskproviders:
     name: Test risk providers
@@ -114,50 +114,50 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew publishCheckoutSnapshotVersion
 
-  upload-examples:
-    needs: publish-checkout
-    name: Upload examples to Browserstack AppLive
+  upload-examplecheckout:
+    needs: [ test-examples, test-paymentservices, test-riskproviders ]
+    name: Upload ExampleCheckout to Browserstack AppLive
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Upload examples to Browserstack AppLive
-      env:
-        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
-        BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-      run: ./gradlew uploadExampleCheckoutToAppLive
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Upload ExampleCheckout to Browserstack AppLive
+        env:
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout
     name: Publish payment service snapshot artifacts
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Publish payment service artifacts
-      env:
-        NEXUS_USER: ${{ secrets.NEXUS_USER }}
-        NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-      run: ./gradlew publishPaymentServicesSnapshotVersion
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Publish payment service artifacts
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+        run: ./gradlew publishPaymentServicesSnapshotVersion
 
   publish-riskproviders:
     needs: publish-checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
       env:
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-        run: ./gradlew uploadExampleCheckoutToAppLive
+      run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
       env:
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-        run: ./gradlew uploadExampleAppsToAppLive
+        run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,28 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: ./gradlew publishCheckoutSnapshotVersion
 
+  upload-examples:
+    needs: publish-checkout
+    name: Upload examples to Browserstack AppLive
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout with submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Clean checkout project
+      run: ./gradlew clean
+    - name: Upload examples to Browserstack AppLive
+      env:
+        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+        BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: ./gradlew uploadExampleAppsToAppLive
+
   publish-paymentservices:
     needs: publish-checkout
     name: Publish payment service snapshot artifacts


### PR DESCRIPTION
## Jira ticket
[PCX-2893](https://optile.atlassian.net/browse/PCX-2893)

## Overview/What
For every merge of a PR into the develop branch, a version of the Example Checkout app should
be automatically uploaded to Browserstack AppLive.

## Cause/Why
As an integration engineer / PO / Support person
I want to be able to access the latest version of our Android SDK example app
so that I can compare feature branches to latest and/or present a stable SDK internally or externally

## Solution
Upload the ExampleCheckout app to AppLive from the build.xml Github workflow.

## Type of change
- New feature (non-breaking change which adds functionality)