### PR TITLE
PCX-2891: Upload ExampleCheckout app for each release to AppLive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
       env:
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-        run: ./gradlew uploadExampleCheckoutToAppLive
+      run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
       env:
         BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
         BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-        run: ./gradlew uploadExampleCheckoutToAppLive
+      run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,22 +56,21 @@ jobs:
     needs: test-checkout
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Build payment services
-      run: ./gradlew buildPaymentServices
-    - name: Run payment service unit-tests
-      run: ./gradlew testPaymentServices
-
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Build payment services
+        run: ./gradlew buildPaymentServices
+      - name: Run payment service unit-tests
+        run: ./gradlew testPaymentServices
 
   test-riskproviders:
     name: Test risk providers
@@ -146,27 +145,27 @@ jobs:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishCheckoutReleaseVersion
 
-  upload-examples:
-    needs: publish-checkout
-    name: Upload examples to Browserstack AppLive
+  upload-examplecheckout:
+    needs: [ publish-checkout ]
+    name: Upload ExampleCheckout to Browserstack AppLive
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout with submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Clean checkout project
-      run: ./gradlew clean
-    - name: Upload examples to Browserstack AppLive
-      env:
-        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
-        BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
-      run: ./gradlew uploadExampleCheckoutToAppLive
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Clean checkout project
+        run: ./gradlew clean
+      - name: Upload ExampleCheckout to Browserstack AppLive
+        env:
+          BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: ./gradlew uploadExampleCheckoutToAppLive
 
   publish-paymentservices:
     needs: publish-checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,28 @@ jobs:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishCheckoutReleaseVersion
 
+  upload-examples:
+    needs: publish-checkout
+    name: Upload examples to Browserstack AppLive
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout with submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Clean checkout project
+      run: ./gradlew clean
+    - name: Upload examples to Browserstack AppLive
+      env:
+        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
+        BROWSERSTACK_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+        run: ./gradlew uploadExampleCheckoutToAppLive
+
   publish-paymentservices:
     needs: publish-checkout
     name: Publish payment service release artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -97,14 +97,12 @@ ext {
 }
 
 static def getBranchName() {
+    // Get branch name for pull requests
     def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
     if ((gitHeadRef != null) && (gitHeadRef.length() > 0)) {
         return gitHeadRef
     }
-    def gitRefName = System.getenv('GITHUB_REF_NAME')
-    if ((gitRefName != null) && (gitRefName.length() > 0)) {
-        return gitRefName
-    }
+    // get branch name for push
     def branch = ''
     def proc = 'git rev-parse --abbrev-ref HEAD'.execute()
     proc.in.eachLine { line -> branch = line }

--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,11 @@ ext {
 
 static def getBranchName() {
     def gitHeadRef = System.getenv('GITHUB_HEAD_REF')
-    if (gitHeadRef != null) {
+    if ((gitHeadRef != null) && (gitHeadRef.length() > 0)) {
         return gitHeadRef
     }
     def gitRefName = System.getenv('GITHUB_REF_NAME')
-    if (gitRefName != null) {
+    if ((gitRefName != null) && (gitRefName.length() > 0)) {
         return gitRefName
     }
     def branch = ''
@@ -115,6 +115,10 @@ static def getBranchName() {
 
 static def getBranchLabel() {
     return getBranchName().replace('[^A-Za-z0-9]', '-')
+}
+
+task testBranch() {
+    printf "test: " + getBranchLabel()
 }
 
 apply from: 'ci.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -117,8 +117,4 @@ static def getBranchLabel() {
     return getBranchName().replace('[^A-Za-z0-9]', '-')
 }
 
-task testBranch() {
-    printf "test: " + getBranchLabel()
-}
-
 apply from: 'ci.gradle'


### PR DESCRIPTION
## Jira ticket
[PCX-2891](https://optile.atlassian.net/browse/PCX-2891)

## Overview/What
Upload release version of the Example Checkout app for each release (merge to master)

## Cause/Why
As an integration engineer / PO / Support person
I want to be able to access the latest version of our Android SDK example app
so that I can compare feature branches to latest and/or present a stable SDK internally or externally

## Solution
Upload example checkout app in the release.xml workflow file

## Type of change
- New feature (non-breaking change which adds functionality)

