### PR TITLE
PCX-3367: Disable GooglePay-Braintree upload to PackageCloud

### DIFF
--- a/example-checkout/build.gradle
+++ b/example-checkout/build.gradle
@@ -91,9 +91,6 @@ dependencies {
     implementation project(":riskprovider:iovation")
     implementation files('../riskprovider/iovation/FraudForce/fraudforce-lib-release-4.3.2.aar')
 
-    // Comment the following line if the googlepay-braintree module should not be loaded
-    implementation project(":paymentservice:googlepay-braintree")
-
     androidTestImplementation project(":shared-test")
     androidTestImplementation "androidx.test:runner:${rootProject.androidxTestRunnerVersion}"
     androidTestImplementation "androidx.test:rules:${rootProject.androidxTestRulesVersion}"

--- a/example-checkout/build.gradle
+++ b/example-checkout/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     // Comment the following two lines to disable the Iovation FraudForce risk provider
     implementation project(":riskprovider:iovation")
     implementation files('../riskprovider/iovation/FraudForce/fraudforce-lib-release-4.3.2.aar')
+
     // Comment the following line if the googlepay-braintree module should not be loaded
     implementation project(":paymentservice:googlepay-braintree")
 

--- a/example-shop/build.gradle
+++ b/example-shop/build.gradle
@@ -98,9 +98,6 @@ dependencies {
     implementation project(":riskprovider:iovation")
     implementation files('../riskprovider/iovation/FraudForce/fraudforce-lib-release-4.3.2.aar')
 
-    // Comment the following line if the googlepay-braintree module should not be loaded
-    implementation project(":paymentservice:googlepay-braintree")
-
     androidTestImplementation project(":shared-test")
     androidTestImplementation "androidx.test:runner:${rootProject.androidxTestRunnerVersion}"
     androidTestImplementation "androidx.test:rules:${rootProject.androidxTestRulesVersion}"

--- a/example-shop/build.gradle
+++ b/example-shop/build.gradle
@@ -95,6 +95,9 @@ dependencies {
     implementation project(":riskprovider:iovation")
     implementation files('../riskprovider/iovation/FraudForce/fraudforce-lib-release-4.3.2.aar')
 
+    // Comment the following line if the googlepay-braintree module should not be loaded
+    implementation project(":paymentservice:googlepay-braintree")
+
     androidTestImplementation project(":shared-test")
     androidTestImplementation "androidx.test:runner:${rootProject.androidxTestRunnerVersion}"
     androidTestImplementation "androidx.test:rules:${rootProject.androidxTestRulesVersion}"

--- a/paymentservice/googlepay-braintree/README.md
+++ b/paymentservice/googlepay-braintree/README.md
@@ -1,0 +1,6 @@
+Title: GooglePay-Braintree PaymentService
+
+# GooglePay-Braintree PaymentService
+
+This GooglePay-Braintree PaymentService is not publicly released yet because it is under active development.
+Until it is officially supported, this PaymentService must not be used.

--- a/paymentservice/googlepay-braintree/README.md
+++ b/paymentservice/googlepay-braintree/README.md
@@ -2,5 +2,5 @@ Title: GooglePay-Braintree PaymentService
 
 # GooglePay-Braintree PaymentService
 
-This GooglePay-Braintree PaymentService is under development and not publicly released yet.
-This PaymentService must not be used until officially released and supported.
+The GooglePay-Braintree PaymentService is under development and not publicly released yet.
+Therefore, this PaymentService must not be used until officially released and supported.

--- a/paymentservice/googlepay-braintree/README.md
+++ b/paymentservice/googlepay-braintree/README.md
@@ -2,5 +2,4 @@ Title: GooglePay-Braintree PaymentService
 
 # GooglePay-Braintree PaymentService
 
-This GooglePay-Braintree PaymentService is not publicly released yet because it is under active development.
-Until it is officially supported, this PaymentService must not be used.
+This GooglePay-Braintree PaymentService is not publicly released yet and therefore must not be used.

--- a/paymentservice/googlepay-braintree/README.md
+++ b/paymentservice/googlepay-braintree/README.md
@@ -2,4 +2,5 @@ Title: GooglePay-Braintree PaymentService
 
 # GooglePay-Braintree PaymentService
 
-This GooglePay-Braintree PaymentService is not publicly released yet and therefore must not be used.
+This GooglePay-Braintree PaymentService is under development and not publicly released yet.
+This PaymentService must not be used until officially released and supported.

--- a/paymentservice/googlepay-braintree/publish.gradle
+++ b/paymentservice/googlepay-braintree/publish.gradle
@@ -37,7 +37,7 @@ afterEvaluate {
                             (publication == publishing.publications.nexusReleases) &&
                             (rootProject.isReleaseVersion()))
 
-            // Uploading of this GooglePay-Braintree PaymentService to PackageCloud is disabled until it is officially supported.
+            // TODO: Uploading of this GooglePay-Braintree PaymentService to PackageCloud is disabled until it is officially supported.
             //((repository == publishing.repositories.packagecloud) &&
             //        (publication == publishing.publications.packagecloud) &&
             //        (rootProject.isReleaseVersion()))

--- a/paymentservice/googlepay-braintree/publish.gradle
+++ b/paymentservice/googlepay-braintree/publish.gradle
@@ -35,11 +35,12 @@ afterEvaluate {
 
                     ((repository == publishing.repositories.nexusReleases) &&
                             (publication == publishing.publications.nexusReleases) &&
-                            (rootProject.isReleaseVersion())) ||
-
-                    ((repository == publishing.repositories.packagecloud) &&
-                            (publication == publishing.publications.packagecloud) &&
                             (rootProject.isReleaseVersion()))
+
+            // Uploading of this GooglePay-Braintree PaymentService to PackageCloud is disabled until it is officially supported.
+            //((repository == publishing.repositories.packagecloud) &&
+            //        (publication == publishing.publications.packagecloud) &&
+            //        (rootProject.isReleaseVersion()))
         }
     }
     publishing {


### PR DESCRIPTION
## Jira ticket
[PCX-3367](https://optile.atlassian.net/browse/PCX-3367)

## Overview/What
Disable upload of the GooglePay-Braintree PaymentService to PackageCloud.

## Cause/Why
GooglePay-Braintree PaymentService is under active development and thus it should not
be publicly released.

## Solution
Disable upload to PackageCloud

## Type of change
- New feature (non-breaking change which adds functionality)
