### PR TITLE
PCX-3605: Use ViewMatcher to find the proper Activity

### DIFF
--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseJavaTest.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseJavaTest.java
@@ -10,9 +10,9 @@
 
 package com.payoneer.checkout.examplecheckout;
 
-import org.junit.Rule;
+import static com.payoneer.checkout.sharedtest.view.PaymentActions.getActivityWithClass;
 
-import com.payoneer.checkout.sharedtest.view.ActivityHelper;
+import org.junit.Rule;
 
 import androidx.test.espresso.IdlingResource;
 import androidx.test.rule.ActivityTestRule;
@@ -24,7 +24,7 @@ public abstract class BaseJavaTest extends BaseTest {
     public ActivityTestRule<ExampleCheckoutJavaActivity> rule = new ActivityTestRule<>(ExampleCheckoutJavaActivity.class);
 
     protected IdlingResource getResultIdlingResource() {
-        ExampleCheckoutJavaActivity activity = (ExampleCheckoutJavaActivity) ActivityHelper.getCurrentActivity();
+        ExampleCheckoutJavaActivity activity = (ExampleCheckoutJavaActivity) getActivityWithClass(ExampleCheckoutJavaActivity.class);
         return activity.getResultHandledIdlingResource();
     }
 }

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseKotlinTest.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/BaseKotlinTest.java
@@ -10,9 +10,9 @@
 
 package com.payoneer.checkout.examplecheckout;
 
-import org.junit.Rule;
+import static com.payoneer.checkout.sharedtest.view.PaymentActions.getActivityWithClass;
 
-import com.payoneer.checkout.sharedtest.view.ActivityHelper;
+import org.junit.Rule;
 
 import androidx.test.espresso.IdlingResource;
 import androidx.test.rule.ActivityTestRule;
@@ -25,7 +25,7 @@ public abstract class BaseKotlinTest extends BaseTest {
 
     @Override
     protected IdlingResource getResultIdlingResource() {
-        ExampleCheckoutKotlinActivity activity = (ExampleCheckoutKotlinActivity) ActivityHelper.getCurrentActivity();
+        ExampleCheckoutKotlinActivity activity = (ExampleCheckoutKotlinActivity) getActivityWithClass(ExampleCheckoutKotlinActivity.class);
         return activity.getResultHandledIdlingResource();
     }
 }

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
@@ -39,6 +39,7 @@ import org.hamcrest.Matcher;
 
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.sharedtest.view.ActivityHelper;
+import com.payoneer.checkout.sharedtest.view.PaymentActions;
 import com.payoneer.checkout.ui.screen.idlingresource.PaymentIdlingResources;
 import com.payoneer.checkout.ui.screen.list.PaymentListActivity;
 
@@ -51,7 +52,7 @@ public final class PaymentListHelper {
 
     public static PaymentListActivity waitForPaymentListLoaded(final int count) {
         intended(hasComponent(PaymentListActivity.class.getName()), times(count));
-        PaymentListActivity listActivity = (PaymentListActivity) ActivityHelper.getCurrentActivity();
+        PaymentListActivity listActivity = (PaymentListActivity) PaymentActions.getActivityWithClass(PaymentListActivity.class);
         PaymentIdlingResources idlingResources = listActivity.getPaymentIdlingResources();
         IdlingResource loadIdlingResource = idlingResources.getLoadIdlingResource();
 

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/ProcessPaymentHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/ProcessPaymentHelper.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import com.payoneer.checkout.R;
-import com.payoneer.checkout.sharedtest.view.ActivityHelper;
+import com.payoneer.checkout.sharedtest.view.PaymentActions;
 import com.payoneer.checkout.ui.screen.idlingresource.PaymentIdlingResources;
 import com.payoneer.checkout.ui.screen.payment.ProcessPaymentActivity;
 
@@ -30,7 +30,7 @@ public final class ProcessPaymentHelper {
 
     public static void waitForProcessPaymentDialog() {
         intended(hasComponent(ProcessPaymentActivity.class.getName()));
-        ProcessPaymentActivity paymentActivity = (ProcessPaymentActivity) ActivityHelper.getCurrentActivity();
+        ProcessPaymentActivity paymentActivity = (ProcessPaymentActivity) PaymentActions.getActivityWithClass(ProcessPaymentActivity.class);
         PaymentIdlingResources idlingResources = paymentActivity.getPaymentIdlingResources();
         IdlingResource dialogIdlingResource = idlingResources.getDialogIdlingResource();
 

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentActions.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentActions.java
@@ -15,16 +15,19 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.hasContextWithClass;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 
 import com.payoneer.checkout.ui.list.PaymentCardViewHolder;
 import com.payoneer.checkout.ui.widget.FormWidget;
 import com.payoneer.checkout.util.PaymentUtils;
 
+import android.app.Activity;
 import android.text.SpannableString;
 import android.text.style.ClickableSpan;
 import android.view.View;
@@ -34,6 +37,7 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.espresso.Espresso;
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.espresso.UiController;
@@ -245,6 +249,27 @@ public final class PaymentActions {
                 ((NumberPicker) view).setValue(value);
             }
         };
+    }
+
+    public static Activity getActivityWithClass(final Class<? extends Activity> clazz) {
+        final Activity[] currentActivity = new Activity[1];
+        Espresso.onView(AllOf.allOf(ViewMatchers.withId(android.R.id.content), isDisplayed())).perform(new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return hasContextWithClass(clazz);
+            }
+
+            @Override
+            public String getDescription() {
+                return "get payment activity with provided class";
+            }
+
+            @Override
+            public void perform(UiController uiController, View view) {
+                currentActivity[0] = ((Activity) view.getContext());
+            }
+        });
+        return currentActivity[0];
     }
 
     private static PerformException createPerformException(String actionDescription, String viewDescription) {

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentMatchers.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentMatchers.java
@@ -123,6 +123,20 @@ public final class PaymentMatchers {
         };
     }
 
+    public static Matcher<View> hasContextWithClass(final Class clazz) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public boolean matchesSafely(View view) {
+                return view.getContext().getClass().equals(clazz);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(PaymentUtils.format("Match view with Context with Class %s", clazz.getName()));
+            }
+        };
+    }
+
     public static Matcher<View> linearLayoutWithChildCount(final int childCount) {
         return new TypeSafeMatcher<View>() {
             @Override


### PR DESCRIPTION
## Jira ticket
[PCX-3605](https://optile.atlassian.net/browse/PCX-3605)

## Overview/What
On rare occasions the getCurrentActivity returns the invalid activity although the Intent is launched.

## Cause/Why
Automated tests are randomly failing on Browserstack

## Solution
Obtain the current activity using ViewMatchers instead of using the ActivityHelper class

## Type of change
- Bug fix (non-breaking change which fixes an issue)

