### PR TITLE
PCX-3608 Updated NEXUS credentials.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,8 +110,8 @@ jobs:
         run: ./gradlew clean
       - name: Publish checkout artifact
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
         run: ./gradlew publishCheckoutSnapshotVersion
 
   upload-examplecheckout:
@@ -154,8 +154,8 @@ jobs:
         run: ./gradlew clean
       - name: Publish payment service artifacts
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishPaymentServicesSnapshotVersion
 
@@ -177,6 +177,6 @@ jobs:
         run: ./gradlew clean
       - name: Publish risk provider artifacts
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
         run: ./gradlew publishRiskProvidersSnapshotVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,8 @@ jobs:
         run: ./gradlew clean
       - name: Publish release artifact
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishCheckoutReleaseVersion
 
@@ -185,8 +185,8 @@ jobs:
         run: ./gradlew clean
       - name: Publish payment service artifacts
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishPaymentServicesReleaseVersion
 
@@ -208,7 +208,7 @@ jobs:
         run: ./gradlew clean
       - name: Publish risk provider artifacts
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_USER: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARTIFACT_ROOT_ACCESS_PASSWORD }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         run: ./gradlew publishRiskProvidersReleaseVersion


### PR DESCRIPTION
## Jira ticket
[PCX-3608](https://optile.atlassian.net/browse/PCX-3608)

## Overview/What
Update NEXUS secrets in Android workflow files

## Cause/Why
Android Checkout SDK builds and releases are broken because of invalid NEXUS credentials used in Github.

## Solution
Switch to new values for NEXUS.

## Type of change
- Bug fix (non-breaking change which fixes an issue)