### PR TITLE
PCX-3630 Switched to a proper value for the providerCode when finaliz…

### DIFF
--- a/checkout/src/main/java/com/payoneer/checkout/util/PaymentUtils.java
+++ b/checkout/src/main/java/com/payoneer/checkout/util/PaymentUtils.java
@@ -340,6 +340,23 @@ public final class PaymentUtils {
     }
 
     /**
+     * Get the provider code from the operation result
+     *
+     * @param result the operation result
+     * @return the provider code or null if not found
+     */
+    public static String getProviderCode(OperationResult result) {
+        if (result == null) {
+            return null;
+        }
+        ProviderParameters parameters = result.getProviderResponse();
+        if (parameters == null) {
+            return null;
+        }
+        return parameters.getProviderCode();
+    }
+
+    /**
      * Check if the redirect type exists in the OperationResult
      *
      * @param operationResult contains the Redirect object

--- a/paymentservice/googlepay-braintree/src/main/java/com/payoneer/checkout/payment/googlepaybraintree/GooglePayBraintreePaymentService.java
+++ b/paymentservice/googlepay-braintree/src/main/java/com/payoneer/checkout/payment/googlepaybraintree/GooglePayBraintreePaymentService.java
@@ -94,6 +94,7 @@ public class GooglePayBraintreePaymentService extends PaymentService {
         this.processPaymentData = null;
         this.applicationContext = null;
         this.fragmentResult = null;
+        this.providerCode = null;
         operationService.stop();
     }
 
@@ -208,10 +209,12 @@ public class GooglePayBraintreePaymentService extends PaymentService {
             return;
         }
 
-        this.providerCode = PaymentUtils.getProviderCode(operationResult);
-        if (TextUtils.isEmpty(this.providerCode)) {
+        String providerCode = PaymentUtils.getProviderCode(operationResult);
+        if (TextUtils.isEmpty(providerCode)) {
             closeWithProcessErrorMessage("Missing GooglePayBraintree provider code");
             return;
+        } else {
+            this.providerCode = providerCode;
         }
 
         try {

--- a/paymentservice/googlepay-braintree/src/main/java/com/payoneer/checkout/payment/googlepaybraintree/GooglePayBraintreePaymentService.java
+++ b/paymentservice/googlepay-braintree/src/main/java/com/payoneer/checkout/payment/googlepaybraintree/GooglePayBraintreePaymentService.java
@@ -60,6 +60,7 @@ public class GooglePayBraintreePaymentService extends PaymentService {
     private Context applicationContext;
     private ProcessPaymentData processPaymentData;
     private Bundle fragmentResult;
+    private String providerCode;
     private int state;
 
     /**
@@ -137,6 +138,10 @@ public class GooglePayBraintreePaymentService extends PaymentService {
             closeWithProcessErrorMessage("Missing GooglePayBraintree fragment result after onResume");
             return;
         }
+        if (providerCode == null) {
+            closeWithProcessErrorMessage("Missing GooglePayBraintree provider code");
+            return;
+        }
         if (!(fragmentResult.containsKey(BRAINTREE_NONCE))) {
             Exception exception = (Exception) fragmentResult.getSerializable(BRAINTREE_ERROR);
             closeWithProcessPaymentInterrupted(exception);
@@ -144,7 +149,7 @@ public class GooglePayBraintreePaymentService extends PaymentService {
         }
         PaymentMethodNonce nonce = fragmentResult.getParcelable(BRAINTREE_NONCE);
         ProviderParameters providerRequest = new ProviderParameters();
-        providerRequest.setProviderCode(processPaymentData.getNetworkCode());
+        providerRequest.setProviderCode(providerCode);
 
         List<Parameter> params = new ArrayList<>();
         Parameter param = new Parameter();
@@ -202,6 +207,13 @@ public class GooglePayBraintreePaymentService extends PaymentService {
             closeWithProcessErrorMessage("Missing GooglePayBraintree [" + BRAINTREE_AUTHORIZATION + "] parameter");
             return;
         }
+
+        this.providerCode = PaymentUtils.getProviderCode(operationResult);
+        if (TextUtils.isEmpty(this.providerCode)) {
+            closeWithProcessErrorMessage("Missing GooglePayBraintree provider code");
+            return;
+        }
+
         try {
             GooglePayRequest request = GooglePayRequestBuilder.of(operationResult);
             Bundle arguments = new Bundle();


### PR DESCRIPTION
…ing payment via GooglePay

## Jira ticket
[PCX-3630](https://optile.atlassian.net/browse/PCX-3630)

## Overview/What
Making a GooglePay charge request using direct charge or preset flow, it fails with a TRY_OTHER_ACCOUNT/INVALID_ACCOUNT interaction code and reason.

## Cause/Why
The GooglePayBraintreePaymentService sends in the providerRequest the network code for the providerCode value. This is incorrect.

## Solution
The GooglePayBraintreePaymentService should send the providerCode value, received in the onSelect result, for the final charge request.

## Type of change
- Bug fix (non-breaking change which fixes an issue)