### PR TITLE
PCX-3503: Validate checkbox states

### DIFF
--- a/checkout/src/main/java/com/payoneer/checkout/model/Checkbox.java
+++ b/checkout/src/main/java/com/payoneer/checkout/model/Checkbox.java
@@ -8,6 +8,8 @@
 
 package com.payoneer.checkout.model;
 
+import androidx.annotation.NonNull;
+
 /**
  * This class is designed to hold information checkbox element that is displayed on payment page.
  */
@@ -26,6 +28,15 @@ public class Checkbox {
         this.mode = mode;
     }
 
+    public void setRequiredMessage(final String requiredMessage) {
+        this.requiredMessage = requiredMessage;
+    }
+
+    public String getRequiredMessage() {
+        return requiredMessage;
+    }
+
+    @NonNull
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();

--- a/checkout/src/main/java/com/payoneer/checkout/ui/widget/CheckboxWidget.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/widget/CheckboxWidget.java
@@ -116,13 +116,9 @@ public class CheckboxWidget extends FormWidget {
             case CheckboxMode.OPTIONAL_PRESELECTED:
             case CheckboxMode.REQUIRED_PRESELECTED:
             case CheckboxMode.FORCED_DISPLAYED:
+            case CheckboxMode.FORCED:
                 setVisible(true);
                 switchView.setVisibility(View.VISIBLE);
-                switchView.setChecked(true);
-                break;
-            case CheckboxMode.FORCED:
-                setVisible(false);
-                switchView.setVisibility(View.GONE);
                 switchView.setChecked(true);
                 break;
             default:

--- a/checkout/src/main/java/com/payoneer/checkout/ui/widget/CheckboxWidget.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/widget/CheckboxWidget.java
@@ -8,12 +8,20 @@
 
 package com.payoneer.checkout.ui.widget;
 
+import static com.payoneer.checkout.model.CheckboxMode.FORCED;
+import static com.payoneer.checkout.model.CheckboxMode.FORCED_DISPLAYED;
+import static com.payoneer.checkout.model.CheckboxMode.REQUIRED;
+import static com.payoneer.checkout.model.CheckboxMode.REQUIRED_PRESELECTED;
+
+import java.util.Objects;
+
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.payoneer.checkout.R;
 import com.payoneer.checkout.markdown.MarkdownSpannableStringBuilder;
 import com.payoneer.checkout.model.CheckboxMode;
 import com.payoneer.checkout.payment.PaymentInputValues;
 
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +34,9 @@ public class CheckboxWidget extends FormWidget {
 
     SwitchMaterial switchView;
     TextView labelView;
+    TextView errorView;
+    String mode;
+    String requiredMessage;
 
     public CheckboxWidget(String category, String name) {
         super(category, name);
@@ -35,14 +46,50 @@ public class CheckboxWidget extends FormWidget {
     public View inflate(ViewGroup parent) {
         inflateWidgetView(parent, R.layout.widget_checkbox);
         labelView = widgetView.findViewById(R.id.label_checkbox);
+        errorView = widgetView.findViewById(R.id.error_view);
         switchView = widgetView.findViewById(R.id.switch_checkbox);
         labelView.setMovementMethod(LinkMovementMethod.getInstance());
+
+        switchView.setOnClickListener((view -> {
+            handleSwitchClicked(switchView.isChecked());
+        }));
         return widgetView;
+    }
+
+    private void handleSwitchClicked(final boolean isChecked) {
+        showRequiredMessage(!isChecked && (Objects.equals(mode, REQUIRED) || Objects.equals(mode, REQUIRED_PRESELECTED)));
     }
 
     @Override
     public void putValue(final PaymentInputValues inputValues) {
         inputValues.putBooleanValue(category, name, switchView.isChecked());
+    }
+
+    @Override
+    public boolean validate() {
+        boolean checked = switchView.isChecked();
+        switch (mode) {
+            case REQUIRED:
+            case REQUIRED_PRESELECTED:
+                if (!checked) {
+                    showRequiredMessage(true);
+                    return false;
+                }
+                break;
+            case FORCED:
+            case FORCED_DISPLAYED:
+                return checked;
+        }
+        return true;
+    }
+
+    private void showRequiredMessage(final boolean show) {
+        if (show && !TextUtils.isEmpty(requiredMessage)) {
+            errorView.setVisibility(View.VISIBLE);
+            errorView.setText(requiredMessage);
+        } else {
+            errorView.setVisibility(View.GONE);
+        }
     }
 
     /**
@@ -53,28 +100,28 @@ public class CheckboxWidget extends FormWidget {
      * @param mode checkbox mode
      * @param label shown to the user
      */
-    public void onBind(String mode, String label) {
+    public void onBind(String mode, String label, String requiredMessage) {
+        this.mode = mode;
         labelView.setText(MarkdownSpannableStringBuilder.createFromText(label));
+        this.requiredMessage = requiredMessage;
+
+        showRequiredMessage(false);
         switch (mode) {
             case CheckboxMode.OPTIONAL:
-            case CheckboxMode.REQUIRED:
+            case REQUIRED:
                 setVisible(true);
                 switchView.setVisibility(View.VISIBLE);
                 switchView.setChecked(false);
                 break;
             case CheckboxMode.OPTIONAL_PRESELECTED:
             case CheckboxMode.REQUIRED_PRESELECTED:
+            case CheckboxMode.FORCED_DISPLAYED:
                 setVisible(true);
                 switchView.setVisibility(View.VISIBLE);
                 switchView.setChecked(true);
                 break;
             case CheckboxMode.FORCED:
                 setVisible(false);
-                switchView.setVisibility(View.GONE);
-                switchView.setChecked(true);
-                break;
-            case CheckboxMode.FORCED_DISPLAYED:
-                setVisible(true);
                 switchView.setVisibility(View.GONE);
                 switchView.setChecked(true);
                 break;

--- a/checkout/src/main/java/com/payoneer/checkout/ui/widget/ExtraElementWidget.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/widget/ExtraElementWidget.java
@@ -8,9 +8,18 @@
 
 package com.payoneer.checkout.ui.widget;
 
+import static com.payoneer.checkout.model.CheckboxMode.FORCED;
+import static com.payoneer.checkout.model.CheckboxMode.FORCED_DISPLAYED;
+import static com.payoneer.checkout.model.CheckboxMode.REQUIRED;
+import static com.payoneer.checkout.model.CheckboxMode.REQUIRED_PRESELECTED;
+
+import java.util.Objects;
+
 import com.payoneer.checkout.model.Checkbox;
 import com.payoneer.checkout.model.CheckboxMode;
 import com.payoneer.checkout.model.ExtraElement;
+
+import android.view.View;
 
 /**
  * Widget for showing the ExtraElement element
@@ -36,5 +45,8 @@ public class ExtraElementWidget extends CheckboxWidget {
             mode = CheckboxMode.NONE;
         }
         super.onBind(mode, extraElement.getLabel(), requiredMessage);
+        if (Objects.equals(mode, FORCED) || Objects.equals(mode, FORCED_DISPLAYED)){
+            switchView.setEnabled(false);
+        }
     }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/widget/ExtraElementWidget.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/widget/ExtraElementWidget.java
@@ -8,9 +8,7 @@
 
 package com.payoneer.checkout.ui.widget;
 
-import android.view.View;
-
-import com.payoneer.checkout.markdown.MarkdownSpannableStringBuilder;
+import com.payoneer.checkout.model.Checkbox;
 import com.payoneer.checkout.model.CheckboxMode;
 import com.payoneer.checkout.model.ExtraElement;
 
@@ -29,32 +27,14 @@ public class ExtraElementWidget extends CheckboxWidget {
      * @param extraElement containing the label and optional checkbox
      */
     public void onBind(ExtraElement extraElement) {
-        String mode = (extraElement.getCheckbox() != null) ? extraElement.getCheckbox().getMode() : CheckboxMode.NONE;
-        labelView.setText(MarkdownSpannableStringBuilder.createFromText(extraElement.getLabel()));
-        switch (mode) {
-            case CheckboxMode.OPTIONAL:
-            case CheckboxMode.REQUIRED:
-                setVisible(true);
-                switchView.setVisibility(View.VISIBLE);
-                switchView.setChecked(false);
-                break;
-            case CheckboxMode.OPTIONAL_PRESELECTED:
-            case CheckboxMode.REQUIRED_PRESELECTED:
-                setVisible(true);
-                switchView.setVisibility(View.VISIBLE);
-                switchView.setChecked(true);
-                break;
-            case CheckboxMode.FORCED_DISPLAYED:
-            case CheckboxMode.FORCED:
-                setVisible(true);
-                switchView.setEnabled(false);
-                switchView.setVisibility(View.VISIBLE);
-                switchView.setChecked(true);
-                break;
-            default:
-                setVisible(false);
-                switchView.setVisibility(View.GONE);
-                switchView.setChecked(false);
+        Checkbox checkbox = extraElement.getCheckbox();
+        String mode;
+        if (checkbox != null) {
+            mode = extraElement.getCheckbox().getMode();
+            requiredMessage = checkbox.getRequiredMessage();
+        } else {
+            mode = CheckboxMode.NONE;
         }
+        super.onBind(mode, extraElement.getLabel(), requiredMessage);
     }
 }

--- a/checkout/src/main/java/com/payoneer/checkout/ui/widget/RegistrationWidget.java
+++ b/checkout/src/main/java/com/payoneer/checkout/ui/widget/RegistrationWidget.java
@@ -13,10 +13,14 @@ import static com.payoneer.checkout.model.RegistrationType.FORCED_DISPLAYED;
 import static com.payoneer.checkout.model.RegistrationType.OPTIONAL;
 import static com.payoneer.checkout.model.RegistrationType.OPTIONAL_PRESELECTED;
 
+import java.util.Objects;
+
 import com.payoneer.checkout.localization.Localization;
 import com.payoneer.checkout.payment.PaymentInputValues;
 import com.payoneer.checkout.ui.model.RegistrationOptions;
 import com.payoneer.checkout.ui.model.RegistrationOptions.RegistrationOption;
+
+import android.view.View;
 
 /**
  * Widget for showing the RegistrationOptions, e.g. allowRecurrence and autoRegistration
@@ -61,6 +65,9 @@ public class RegistrationWidget extends CheckboxWidget {
     public void onBind(RegistrationOptions registrationOptions) {
         this.registrationOptions = registrationOptions;
         String label = Localization.translate(registrationOptions.getLabelKey());
-        super.onBind(registrationOptions.getCheckboxMode(), label);
+        super.onBind(registrationOptions.getCheckboxMode(), label, null);
+        if (Objects.equals(mode, FORCED_DISPLAYED)) {
+            switchView.setVisibility(View.GONE);
+        }
     }
 }

--- a/checkout/src/main/res/layout/widget_checkbox.xml
+++ b/checkout/src/main/res/layout/widget_checkbox.xml
@@ -3,10 +3,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
     android:layout_marginTop="@dimen/pmborder_xsmall"
-    android:layout_marginBottom="@dimen/pmborder_xsmall">
+    android:layout_marginBottom="@dimen/pmborder_xsmall"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
 
     <LinearLayout
         android:layout_width="0dp"
@@ -16,16 +16,24 @@
 
         <TextView
             android:id="@+id/label_checkbox"
-            android:textAppearance="?attr/textAppearanceBody2"
-            android:textColor="?attr/colorOnSurface"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/error_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="?attr/colorError"
+            android:visibility="gone" />
     </LinearLayout>
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/switch_checkbox"
-        android:layout_marginLeft="@dimen/pmborder_xsmall"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/pmborder_xsmall" />
 
 </LinearLayout>

--- a/checkout/src/main/res/values/strings.xml
+++ b/checkout/src/main/res/values/strings.xml
@@ -24,6 +24,4 @@
     <string name="accounts_expired_badge_text">This card has expired. Please update it, or use another payment method.</string>
     <string name="dummy_button">Dummy Button</string>
     <string name="dummy_content">DUMMY\nCONTENT</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -10,14 +10,15 @@
 
 package com.payoneer.checkout.examplecheckout;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
-
-import com.payoneer.checkout.sharedtest.checkout.PaymentListHelper;
-import com.payoneer.checkout.sharedtest.service.ListSettings;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.payoneer.checkout.sharedtest.checkout.PaymentListHelper;
+import com.payoneer.checkout.sharedtest.checkout.TestDataProvider;
+import com.payoneer.checkout.sharedtest.service.ListSettings;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -166,7 +167,7 @@ public final class ExtraElementTests extends BaseKotlinTest {
         PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.OPTIONAL_PRESELECTED", false);
         PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED", true);
         PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED_PRESELECTED", false);
-        PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED", true);
-        PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED_DISPLAYED", true);
+        PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED", false);
+        PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED_DISPLAYED", false);
     }
 }

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -189,7 +189,7 @@ public final class ExtraElementTests extends BaseKotlinTest {
         PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED", "REQUIRED error message");
 
         PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED");
-        PaymentListHelper.checkHasGoneValidationErroText(groupCardIndex, "extraelement.REQUIRED");
+        PaymentListHelper.checkHasGoneValidationErrorText(groupCardIndex, "extraelement.REQUIRED");
 
         PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED_PRESELECTED");
         PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED_PRESELECTED", "REQUIRED_PRESELECTED error message");

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -170,4 +170,28 @@ public final class ExtraElementTests extends BaseKotlinTest {
         PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED", false);
         PaymentListHelper.matchesCheckboxInWidget(groupCardIndex, "extraelement.FORCED_DISPLAYED", false);
     }
+
+    @Test
+    public void testingAllModes_confirmVisibilityAndState_withClickingPayButtonAndTogglingCheckBoxes() {
+        ListSettings settings = createDefaultListSettings();
+        settings.setDivision(DIVISION);
+        settings.setCheckoutConfigurationName(EXTRAELEMENTS_ALL_MODES);
+        enterListUrl(createListUrl(settings));
+        clickShowPaymentListButton();
+
+        int groupCardIndex = 1;
+        PaymentListHelper.waitForPaymentListLoaded(1);
+        PaymentListHelper.openPaymentListCard(groupCardIndex, "card.group");
+        PaymentListHelper.fillPaymentListCard(groupCardIndex, TestDataProvider.visaCardTestData());
+        PaymentListHelper.clickPaymentListCardButton(groupCardIndex);
+
+        PaymentListHelper.scrollToTop();
+        PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED", "REQUIRED error message");
+
+        PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED");
+        PaymentListHelper.checkHasGoneValidationErroText(groupCardIndex, "extraelement.REQUIRED");
+
+        PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED_PRESELECTED");
+        PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED_PRESELECTED", "REQUIRED_PRESELECTED error message");
+    }
 }

--- a/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
+++ b/example-checkout/src/androidTest/java/com/payoneer/checkout/examplecheckout/ExtraElementTests.java
@@ -189,7 +189,7 @@ public final class ExtraElementTests extends BaseKotlinTest {
         PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED", "REQUIRED error message");
 
         PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED");
-        PaymentListHelper.checkHasGoneValidationErrorText(groupCardIndex, "extraelement.REQUIRED");
+        PaymentListHelper.checkValidationErrorTextIsGone(groupCardIndex, "extraelement.REQUIRED");
 
         PaymentListHelper.clickCheckboxInWidget(groupCardIndex, "extraelement.REQUIRED_PRESELECTED");
         PaymentListHelper.matchesValidationErrorText(groupCardIndex, "extraelement.REQUIRED_PRESELECTED", "REQUIRED_PRESELECTED error message");

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
@@ -164,7 +164,7 @@ public final class PaymentListHelper {
         onView(withId(R.id.recyclerview_paymentlist)).perform(scrollToPosition(0));
     }
 
-    public static void checkHasGoneValidationErroText(final int cardIndex, String widgetName) {
+    public static void checkHasGoneValidationErrorText(final int cardIndex, String widgetName) {
         Matcher<View> list = withId(R.id.recyclerview_paymentlist);
         onView(list).check(
             matches(isViewInWidget(cardIndex, withEffectiveVisibility(ViewMatchers.Visibility.GONE), widgetName, R.id.error_view)));

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
@@ -164,7 +164,7 @@ public final class PaymentListHelper {
         onView(withId(R.id.recyclerview_paymentlist)).perform(scrollToPosition(0));
     }
 
-    public static void checkHasGoneValidationErrorText(final int cardIndex, String widgetName) {
+    public static void checkValidationErrorTextIsGone(final int cardIndex, String widgetName) {
         Matcher<View> list = withId(R.id.recyclerview_paymentlist);
         onView(list).check(
             matches(isViewInWidget(cardIndex, withEffectiveVisibility(ViewMatchers.Visibility.GONE), widgetName, R.id.error_view)));

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/checkout/PaymentListHelper.java
@@ -14,16 +14,19 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
+import static androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.times;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.payoneer.checkout.sharedtest.view.PaymentActions.actionOnViewInPaymentCard;
 import static com.payoneer.checkout.sharedtest.view.PaymentActions.actionOnViewInWidget;
 import static com.payoneer.checkout.sharedtest.view.PaymentActions.clickClickableSpan;
+import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.hasTextError;
 import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.hasTextInputLayoutError;
 import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.hasTextInputLayoutValue;
 import static com.payoneer.checkout.sharedtest.view.PaymentMatchers.isCardWithTestId;
@@ -142,9 +145,29 @@ public final class PaymentListHelper {
         onView(list).check(matches(isViewInWidget(cardIndex, hasTextInputLayoutError(errorText), widgetName, R.id.textinputlayout)));
     }
 
+    public static void matchesTextViewErrorTextInWidget(int cardIndex, String widgetName, String errorText) {
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(matches(isViewInWidget(cardIndex, hasTextInputLayoutError(errorText), widgetName, R.id.error_view)));
+    }
+
     public static void matchesInputTextInWidget(int cardIndex, String widgetName, String value) {
         Matcher<View> list = withId(R.id.recyclerview_paymentlist);
         onView(list).check(matches(isViewInWidget(cardIndex, hasTextInputLayoutValue(value), widgetName, R.id.textinputlayout)));
+    }
+
+    public static void matchesValidationErrorText(final int cardIndex, String widgetName, final String errorMessage) {
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(matches(isViewInWidget(cardIndex, hasTextError(errorMessage), widgetName, R.id.error_view)));
+    }
+
+    public static void scrollToTop() {
+        onView(withId(R.id.recyclerview_paymentlist)).perform(scrollToPosition(0));
+    }
+
+    public static void checkHasGoneValidationErroText(final int cardIndex, String widgetName) {
+        Matcher<View> list = withId(R.id.recyclerview_paymentlist);
+        onView(list).check(
+            matches(isViewInWidget(cardIndex, withEffectiveVisibility(ViewMatchers.Visibility.GONE), widgetName, R.id.error_view)));
     }
 
     public static void matchesCheckboxInWidget(int cardIndex, String widgetName, boolean value) {

--- a/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentMatchers.java
+++ b/shared-test/src/main/java/com/payoneer/checkout/sharedtest/view/PaymentMatchers.java
@@ -22,6 +22,7 @@ import com.payoneer.checkout.util.PaymentUtils;
 
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.espresso.matcher.BoundedMatcher;
 
@@ -217,6 +218,27 @@ public final class PaymentMatchers {
                     return false;
                 }
                 CharSequence errorSequence = ((TextInputLayout) view).getError();
+                String inputError = "";
+                if (errorSequence != null) {
+                    inputError = errorSequence.toString();
+                }
+                return inputError.equals(expectedError);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+            }
+        };
+    }
+
+    public static Matcher<View> hasTextError(final String expectedError) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public boolean matchesSafely(View view) {
+                if (!(view instanceof TextView)) {
+                    return false;
+                }
+                CharSequence errorSequence = ((TextView) view).getText();
                 String inputError = "";
                 if (errorSequence != null) {
                     inputError = errorSequence.toString();


### PR DESCRIPTION
## Jira ticket
[PCX-3503](https://optile.atlassian.net/browse/PCX-3503)

## Overview/What
Validate the checkbox modes before submitting them back to OPG. Specifically, validate the ones with either `REQUIRED` or `REQUIRED_PRESELECTED` modes

## Cause/Why
We want to make sure that the users do not send requests if they have not fully agreed to the merchant's conditions

## Solution
Add validation before the states are submitted to OPG

## Type of change
- New feature (non-breaking change which adds functionality)

## Tests
- Changes have been tested in UI tests where we check that the error messages are displayed upon clicking the pay button and upon toggling the `REQUIRED` or `REQUIRED_PRESELECTED` check boxes.
